### PR TITLE
chore(tailscale): bump pinned version 1.84.0 -> 1.98.3

### DIFF
--- a/apps/tailscale/get-tailscale.sh
+++ b/apps/tailscale/get-tailscale.sh
@@ -8,7 +8,7 @@ mkdir /work
 cd /work
 
 
-TAILSCALE_VERSION="1.84.0"
+TAILSCALE_VERSION="1.98.3"
 TAILSCALE_DIRECTORY=/apps/tailscale
 
 


### PR DESCRIPTION
## Summary

Bumps the pinned Tailscale version in `apps/tailscale/get-tailscale.sh` from **1.84.0** to **1.98.3** (current upstream stable).

The catalog currently lags upstream by 14 minor versions, roughly a year of Tailscale releases. The version is baked in at SWU build time, so users installing Tailscale from the Rinkhals Web catalog tab today receive 1.84.0 regardless of what is on pkgs.tailscale.com.

## What this changes

```diff
-TAILSCALE_VERSION="1.84.0"
+TAILSCALE_VERSION="1.98.3"
```

That single line drives the rest:

- The same script downloads `tailscale_${TAILSCALE_VERSION}_arm.tgz` from pkgs.tailscale.com.
- It then rewrites `apps/tailscale/app.json`'s `version` field with `sed`, so the manifest version users see in the Rinkhals Web catalog updates automatically. No manual app.json edit is needed.

## Verification

The 1.98.3 ARM tarball exists upstream:

```
$ curl -sI https://pkgs.tailscale.com/stable/tailscale_1.98.3_arm.tgz | head -2
HTTP/2 200
content-length: 33233620
```

No other changes; this is intentionally minimal so the diff is easy to review and the next Rinkhals.Apps SWU release just rebuilds Tailscale with the newer binary.

## What users will see

Once a new Rinkhals.Apps release ships with this change, users running the Rinkhals Web portal who already have Tailscale 1.84 installed will see an `v1.84.0 -> v1.98.3` upgrade pill on their Tailscale card in the Catalog tab. Fresh installs go straight to 1.98.3.

## Test plan

- [ ] CI rebuilds the per-model SWUs cleanly.
- [ ] Install/upgrade on a K3 or KS1 and confirm `tailscale version` reports 1.98.3.