### PR TITLE
feat(catalog): upstream-tracking schema, version bumps, qr-property advanced flag

### DIFF
--- a/apps/octoapp/app.json
+++ b/apps/octoapp/app.json
@@ -3,7 +3,12 @@
 
     "name": "OctoApp companion",
     "description": "Companion for the OctoApp mobile application",
-    "version": "2.1.10",
+    "version": "3.0.4",
+
+    "upstream": {
+        "type": "github-release",
+        "repo": "crysxd/OctoApp-Plugin"
+    },
 
     "requirements":
     {

--- a/apps/octoapp/get-octoapp.sh
+++ b/apps/octoapp/get-octoapp.sh
@@ -7,7 +7,7 @@ mkdir /work
 cd /work
 
 
-OCTOAPP_VERSION=2.1.10
+OCTOAPP_VERSION=3.0.4
 OCTOAPP_DIRECTORY=/apps/octoapp
 
 

--- a/apps/octoeverywhere/app.json
+++ b/apps/octoeverywhere/app.json
@@ -3,16 +3,22 @@
 
     "name": "OctoEverywhere",
     "description": "A maker community project that enables free remote access, AI failure detection, print notifications, live streaming and more.",
-    "version": "4.1.0",
+    "version": "5.0.2",
+
+    "upstream": {
+        "type": "github-release",
+        "repo": "QuinnDamerell/OctoPrint-OctoEverywhere"
+    },
 
     "requirements": {
         "memory": 20
     },
-    
+
     "properties": {
         "printer_link": {
             "display": "Link your printer",
-            "type": "qr"
+            "type": "qr",
+            "advanced": true
         }
     }
 }

--- a/apps/octoeverywhere/get-octoeverywhere.sh
+++ b/apps/octoeverywhere/get-octoeverywhere.sh
@@ -8,7 +8,7 @@ mkdir /work
 cd /work
 
 
-OCTOEVERYWHERE_VERSION=4.1.0
+OCTOEVERYWHERE_VERSION=5.0.2
 OCTOEVERYWHERE_DIRECTORY=/apps/octoeverywhere
 
 

--- a/apps/tailscale/app.json
+++ b/apps/tailscale/app.json
@@ -3,18 +3,25 @@
 
     "name": "Tailscale",
     "description": "Secure, private network connectivity using Tailscale VPN",
-    "version": "1.84.0",
+    "version": "1.98.3",
     "depends": [],
+
+    "upstream": {
+        "type": "github-release",
+        "repo": "tailscale/tailscale",
+        "strip_prefix": "v"
+    },
 
     "requirements": {
         "cpu": 5,
         "memory": 20
     },
-    
+
     "properties": {
         "account_login": {
             "display": "Connect to Tailscale",
-            "type": "qr"
+            "type": "qr",
+            "advanced": true
         }
     }
 }

--- a/apps/vanilla-klipper/app.json
+++ b/apps/vanilla-klipper/app.json
@@ -3,5 +3,11 @@
 
     "name": "Klipper (vanilla)",
     "description": "Vanilla Klipper to replace Anycubic GoKlipper reimplementation",
-    "version": "0.1"
+    "version": "0.1",
+
+    "upstream": {
+        "type": "github-branch-head",
+        "repo": "Klipper3d/klipper",
+        "branch": "master"
+    }
 }


### PR DESCRIPTION
## Summary

Three coherent changes that together make catalog manifests **proper**: a tracking schema, current-stable version bumps, and a UX flag for non-configurable `qr` properties.

### 1. New optional `upstream` block in `app.json`

Apps that pull binaries from an external source can declare where to find the upstream version. The schema feeds two consumers (both to land next):

- The **Rinkhals Web catalog UI** will surface the live upstream version next to the bundled one so users can see when a catalog entry is stale.
- An **auto-bump CI bot** will watch each app's upstream and open version-bump PRs.

Two source types cover every current case:

```json
"upstream": { "type": "github-release", "repo": "owner/name" }
"upstream": { "type": "github-release", "repo": "...", "strip_prefix": "v" }
"upstream": { "type": "github-branch-head", "repo": "...", "branch": "master" }
```

Added to four apps that actually fetch upstream binaries:

| App | Source |
|---|---|
| tailscale | `github-release` from `tailscale/tailscale` with `strip_prefix: "v"` |
| octoapp | `github-release` from `crysxd/OctoApp-Plugin` |
| octoeverywhere | `github-release` from `QuinnDamerell/OctoPrint-OctoEverywhere` |
| vanilla-klipper | `github-branch-head` from `Klipper3d/klipper` `master` |

The other six apps (`cloud2lan-bridge`, `cloudflare-tunnel`, `discovery-helper`, `nfs-mount`, `remote-debugging`, `stunnel`) are self-contained shell scripts with no upstream binary, so they get no `upstream` block. The field is optional; apps without it work exactly as before.

### 2. Version bumps to current upstream stable

| App | Old | New |
|---|---|---|
| octoapp | 2.1.10 | **3.0.4** |
| octoeverywhere | 4.1.0 | **5.0.2** |

Tailscale was already bumped to 1.98.3 in #1; this PR updates its literal manifest version too (the `get-tailscale.sh` sed already rewrites it at build time, but the literal in source should match what the build emits).

### 3. Advanced flag on `qr`-type properties

Tailscale's `account_login` and OctoEverywhere's `printer_link` are *interactions* (scan a QR code to authenticate or link the printer), not config values. The Rinkhals Web portal renders any non-enum property as a text input, which is meaningless here.

Marking both as `"advanced": true` is a UX hint that:

- Hides the property from the default Configure drawer.
- Lets installs auto-enable cleanly (the post-install `needsConfiguration` check ignores advanced properties).
- Front-panel UI is unaffected (it doesn't honor the flag).

## Verification

All four manifests parse as valid JSON. Upstream tarballs at the new versions return HTTP 200/302 (the GitHub redirect to CDN):

```
$ curl -sI https://github.com/crysxd/OctoApp-Plugin/archive/refs/tags/3.0.4.zip | head -1
HTTP/2 302
$ curl -sI https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/archive/refs/tags/5.0.2.zip | head -1
HTTP/2 302
```

## Test plan

- [ ] CI rebuilds all four apps' SWUs cleanly.
- [ ] On a printer, install or upgrade each of the four apps and confirm the bundled version matches the new pin.
- [ ] (After bot + UI land) `/api/catalog` shows `upstream_version` populated for these four apps and empty for the rest.

## Rolls out as

Once merged + a Rinkhals.Apps release is tagged, users with the existing versions will see upgrade pills (`v2.1.10 -> v3.0.4`, etc.) on their cards in the Rinkhals Web catalog tab automatically (using the upgrade-detection we already wired up earlier).