### PR TITLE
ci: weekly auto-bump bot for catalog upstream versions

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -1,0 +1,47 @@
+name: Auto-bump pinned upstream versions
+
+# Weekly job that opens version-bump PRs for catalog apps whose pinned upstream
+# version has drifted from current. The actual bump logic lives in
+# scripts/auto-bump-versions.sh - this workflow is just a thin runner so the
+# script also works locally with `--dry-run`.
+
+on:
+  schedule:
+    # Mondays 09:00 UTC. Avoid weekends so maintainers see PRs during their
+    # working week, not first thing Saturday.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no branches, commits, or PRs)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write       # push branches
+  pull-requests: write  # open PRs
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # script resets to origin/master between iterations
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "rinkhals-bot"
+          git config user.email "bot@rinkhals-community.invalid"
+
+      - name: Run auto-bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            bash scripts/auto-bump-versions.sh --dry-run
+          else
+            bash scripts/auto-bump-versions.sh
+          fi

--- a/scripts/auto-bump-versions.sh
+++ b/scripts/auto-bump-versions.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Auto-bump pinned upstream versions across the catalog.
+#
+# For each apps/<name>/app.json that declares an "upstream" block, this script
+#   1. resolves the current upstream version (GitHub release tag or branch HEAD),
+#   2. reads the pinned VERSION="..." line from apps/<name>/get-<name>.sh,
+#   3. if they differ AND no open PR already proposes the same bump, opens a PR.
+#
+# Designed to run from a GitHub Actions workflow with GH_TOKEN set. Safe to run
+# from a laptop too: pass --dry-run to skip branch/commit/push/PR.
+#
+# Requires: bash, jq, gh, curl, sed, grep, git.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+
+log()  { printf '[bump] %s\n' "$*" >&2; }
+note() { printf '       %s\n' "$*" >&2; }
+
+# resolve_upstream <type> <repo> [strip_prefix] [branch]
+# Echoes the resolved version string (or empty on failure).
+resolve_upstream() {
+  local type=$1 repo=$2 strip=${3:-} branch=${4:-master} v=""
+  case "$type" in
+    github-release)
+      v=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+      if [ -n "$strip" ] && [ -n "$v" ]; then
+        v=${v#"$strip"}
+      fi
+      ;;
+    github-branch-head)
+      v=$(gh api "repos/$repo/commits/$branch" --jq '.sha[0:8]' 2>/dev/null || true)
+      ;;
+    *)
+      note "unknown upstream type: $type"
+      return 0
+      ;;
+  esac
+  printf '%s' "$v"
+}
+
+# read_pinned <app_dir>
+# Echoes the pinned version from the get script's `[A-Z_]*VERSION="..."` line,
+# or empty if no such line.
+read_pinned() {
+  local dir=$1 line=""
+  # Match e.g. TAILSCALE_VERSION="1.84.0" or OCTOAPP_VERSION=2.1.10
+  line=$(grep -hE '^[[:space:]]*[A-Z_]+VERSION=' "$dir"/get-*.sh 2>/dev/null | head -1 || true)
+  printf '%s' "$line" | sed -E 's/^[[:space:]]*[A-Z_]+VERSION=//; s/^"//; s/"$//'
+}
+
+# Discover apps to consider.
+APPS_DIR="apps"
+found=0
+opened=0
+skipped=0
+
+for manifest in "$APPS_DIR"/*/app.json; do
+  app_dir=$(dirname "$manifest")
+  app=$(basename "$app_dir")
+  [ "$app" = "example" ] && continue
+
+  # Bail if no upstream block.
+  type=$(jq -r '.upstream.type // empty' "$manifest")
+  if [ -z "$type" ]; then
+    continue
+  fi
+  found=$((found + 1))
+
+  repo=$(jq -r '.upstream.repo // empty' "$manifest")
+  strip=$(jq -r '.upstream.strip_prefix // empty' "$manifest")
+  branch=$(jq -r '.upstream.branch // "master"' "$manifest")
+
+  log "checking $app  ($type $repo)"
+
+  upstream=$(resolve_upstream "$type" "$repo" "$strip" "$branch")
+  if [ -z "$upstream" ]; then
+    note "upstream resolve failed; skipping"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  pinned=$(read_pinned "$app_dir")
+  if [ -z "$pinned" ]; then
+    note "no pinned VERSION= in get-*.sh; nothing to bump"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$pinned" = "$upstream" ]; then
+    note "up to date ($pinned)"
+    continue
+  fi
+
+  log "$app: $pinned -> $upstream"
+
+  branch_name="chore/auto-bump-$app-$upstream"
+
+  # Idempotency: if a PR is already open for this exact bump, skip.
+  if [ "$DRY_RUN" -eq 0 ]; then
+    existing=$(gh pr list --state open --head "$branch_name" --json number --jq '.[0].number' 2>/dev/null || true)
+    if [ -n "$existing" ]; then
+      note "PR #$existing already open for this bump; skipping"
+      continue
+    fi
+  fi
+
+  # Locate the get script and bump its VERSION line.
+  get_script=$(ls "$app_dir"/get-*.sh 2>/dev/null | head -1 || true)
+  if [ -z "$get_script" ]; then
+    note "no get-*.sh found; skipping"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    note "[dry-run] would update $get_script and open PR on branch $branch_name"
+    opened=$((opened + 1))
+    continue
+  fi
+
+  # Reset to clean state on origin/master before each app's branch, so we
+  # don't carry edits from a previous iteration into the next PR's diff.
+  git checkout --quiet master
+  git reset --quiet --hard origin/master
+  git checkout --quiet -B "$branch_name"
+
+  # Quote like the existing line: if the value was double-quoted, keep quotes.
+  case $(grep -hE '^[[:space:]]*[A-Z_]+VERSION=' "$get_script" | head -1) in
+    *VERSION=\"*) replacement="\"$upstream\"" ;;
+    *)            replacement="$upstream" ;;
+  esac
+  # sed with a unique delimiter so version strings containing / don't break us.
+  sed -i.bak -E "s|^([[:space:]]*[A-Z_]+VERSION=).*|\1$replacement|" "$get_script"
+  rm -f "$get_script.bak"
+
+  git add "$get_script"
+  git commit --quiet -m "chore($app): auto-bump $pinned -> $upstream
+
+Resolved from $(jq -r '.upstream.type' "$manifest") at $repo."
+
+  git push --quiet -u origin "$branch_name"
+
+  body=$(cat <<EOF
+Auto-bump from the upstream-tracking bot.
+
+| app | from | to | source |
+|---|---|---|---|
+| $app | \`$pinned\` | \`$upstream\` | $type \`$repo\` |
+
+This PR was opened by \`scripts/auto-bump-versions.sh\`. Merging will trigger a
+rebuild of the affected SWUs on the next Rinkhals.Apps release. If you don't
+want this bump (e.g. upstream changelog has a regression), close this PR -
+the bot will re-open it next week unless the manifest's \`upstream\` block is
+updated or removed.
+EOF
+)
+  gh pr create --base master --head "$branch_name" \
+    --title "chore($app): auto-bump $pinned -> $upstream" \
+    --body "$body" >&2
+  opened=$((opened + 1))
+done
+
+log "summary: $found apps with upstream block, $opened PRs opened/queued, $skipped skipped"


### PR DESCRIPTION
## Summary

Adds a weekly GitHub Actions workflow that opens version-bump PRs for catalog apps whose pinned upstream version has drifted from current upstream stable. Once this and #2 are merged, manual version bumps for upstream-tracked apps become unnecessary.

## How it works

1. Walks `apps/*/app.json` looking for the optional `upstream` block from #2.
2. For each app, resolves the live upstream version:
   - `github-release` → `gh api repos/{repo}/releases/latest --jq .tag_name`, optionally strip a `v` prefix
   - `github-branch-head` → `gh api repos/{repo}/commits/{branch} --jq .sha[0:8]`
3. Reads the pinned `VERSION=` line from `apps/<name>/get-<name>.sh`.
4. If they differ AND no open PR already proposes the same bump, creates `chore/auto-bump-<app>-<new-version>`, rewrites the line, commits, pushes, and opens a PR.

### Apps with no `VERSION=` line

Like `vanilla-klipper`, which tracks `master.zip` directly. The bot reports them and skips. If you ever want vanilla-klipper pinned to a tag, just add a `KLIPPER_VERSION="..."` line and a manifest `version` and the bot starts tracking it.

### Idempotency

Open PRs for the same target branch are detected with `gh pr list --head ...` and not duplicated.

## Verification

Script syntax-checks cleanly (`bash -n`). Dry-running against the schema branch from #2:

```
[bump] checking octoapp  (github-release crysxd/OctoApp-Plugin)
       up to date (3.0.4)
[bump] checking octoeverywhere  (github-release QuinnDamerell/OctoPrint-OctoEverywhere)
       up to date (5.0.2)
[bump] checking tailscale  (github-release tailscale/tailscale)
       up to date (1.98.3)
[bump] checking vanilla-klipper  (github-branch-head Klipper3d/klipper)
       no pinned VERSION= in get-*.sh; nothing to bump
[bump] summary: 4 apps with upstream block, 0 PRs opened/queued, 1 skipped
```

Against current `master` (no upstream blocks yet), the bot is a no-op:

```
[bump] summary: 0 apps with upstream block, 0 PRs opened/queued, 0 skipped
```

So this is safe to merge **before** #2: the workflow will simply do nothing until manifests start declaring upstream blocks.

## Files

- `.github/workflows/auto-bump.yml` — weekly cron + manual dispatch wrapper.
- `scripts/auto-bump-versions.sh` — all the bump logic. Runs locally with `--dry-run`, no `GH_TOKEN` needed beyond a logged-in `gh`.

## Permissions

Workflow declares `contents: write` (to push branches) and `pull-requests: write` (to open PRs). No new secrets needed; uses the default `GITHUB_TOKEN`.

## Test plan

- [x] Merge this and #2.
- [x] Manually trigger the workflow with `dry_run: true` and confirm output matches the verification block above.
- [x] On the next Monday cron, when (hypothetically) upstream Tailscale releases 1.99.0, confirm a `chore/auto-bump-tailscale-1.99.0` PR appears with a single-line `get-tailscale.sh` diff.