### PR TITLE
chore(vanilla-klipper): pin to master b7c0329f, sync app.json version

### DIFF
--- a/apps/vanilla-klipper/app.json
+++ b/apps/vanilla-klipper/app.json
@@ -3,7 +3,7 @@
 
     "name": "Klipper (vanilla)",
     "description": "Vanilla Klipper to replace Anycubic GoKlipper reimplementation",
-    "version": "0.1",
+    "version": "b7c0329f",
 
     "upstream": {
         "type": "github-branch-head",

--- a/apps/vanilla-klipper/get-klipper.sh
+++ b/apps/vanilla-klipper/get-klipper.sh
@@ -7,17 +7,29 @@ mkdir /work
 cd /work
 
 
-# Klipper
-echo "Downloading Klipper..."
+# Klipper - pinned to a specific master commit so each SWU build is
+# reproducible. The Rinkhals.Apps auto-bump bot watches this against
+# Klipper3d/klipper master and opens a PR when upstream moves; do not
+# revert to master.zip without disabling the bot for this app.
+KLIPPER_VERSION="b7c0329f"
+KLIPPER_DIRECTORY=/apps/vanilla-klipper
 
-wget -O klipper.zip https://github.com/Klipper3d/klipper/archive/refs/heads/master.zip
+
+echo "Downloading Klipper $KLIPPER_VERSION..."
+
+wget -O klipper.zip https://github.com/Klipper3d/klipper/archive/${KLIPPER_VERSION}.zip
 unzip -d klipper klipper.zip
 
-mkdir -p /apps/vanilla-klipper/klippy
-rm -rf /apps/vanilla-klipper/klippy/*
+mkdir -p $KLIPPER_DIRECTORY/klippy
+rm -rf $KLIPPER_DIRECTORY/klippy/*
 
-cp -pr /work/klipper/*/klippy/* /apps/vanilla-klipper/klippy/
-cp -p /work/klipper/*/scripts/klippy-requirements.txt /apps/vanilla-klipper/
+cp -pr /work/klipper/*/klippy/* $KLIPPER_DIRECTORY/klippy/
+cp -p /work/klipper/*/scripts/klippy-requirements.txt $KLIPPER_DIRECTORY/
 
-cd /apps/vanilla-klipper
+cd $KLIPPER_DIRECTORY
 patch -p0 < klippy.patch
+
+# Keep app.json's version field in sync with the pinned commit so the
+# Rinkhals Web catalog shows the right value and the bot's drift check
+# sees the same source of truth.
+sed -i "s/\"version\": *\"[^\"]*\"/\"version\": \"${KLIPPER_VERSION}\"/" $KLIPPER_DIRECTORY/app.json


### PR DESCRIPTION
## Summary

Completes vanilla-klipper's catalog story. Two changes:

### 1. Pin the build to a specific master commit

`get-klipper.sh` previously fetched `master.zip`, so each SWU build captured whatever master HEAD happened to be at build time. That made the build non-reproducible and the manifest version meaningless (it was hardcoded to `0.1` and never tracked anything).

```diff
-wget -O klipper.zip https://github.com/Klipper3d/klipper/archive/refs/heads/master.zip
+KLIPPER_VERSION="b7c0329f"
+wget -O klipper.zip https://github.com/Klipper3d/klipper/archive/${KLIPPER_VERSION}.zip
```

GitHub serves commit-archive URLs for any sha (`HTTP 302` → CDN). Verified:

```
$ curl -sI https://github.com/Klipper3d/klipper/archive/b7c0329f.zip | head -1
HTTP/2 302
```

### 2. Sync the manifest version

`app.json`'s `version` becomes `"b7c0329f"` to match. The get script also includes a `sed` line at the bottom that rewrites it at build time (same pattern as `tailscale`, `octoapp`, `octoeverywhere`), so the variable and the manifest can't drift apart.

## How this plays with the bot (#3)

The bot's dry-run now reports all four upstream-tracked apps as up to date:

```
[bump] checking octoapp  (github-release crysxd/OctoApp-Plugin)
       up to date (3.0.4)
[bump] checking octoeverywhere  (github-release QuinnDamerell/OctoPrint-OctoEverywhere)
       up to date (5.0.2)
[bump] checking tailscale  (github-release tailscale/tailscale)
       up to date (1.98.3)
[bump] checking vanilla-klipper  (github-branch-head Klipper3d/klipper)
       up to date (b7c0329f)
```

After this lands, future Klipper master commits trigger a weekly bot PR:

1. Bot resolves `Klipper3d/klipper@master` → new sha8.
2. Compares to `KLIPPER_VERSION="b7c0329f"` in `get-klipper.sh`.
3. Opens `chore/auto-bump-vanilla-klipper-<new-sha8>` with a one-line diff.

Reviewer skims the upstream diff (the PR description includes a comparison link template) and merges, or closes if there's a known regression.

## Note on cadence

Klipper master moves frequently; weekly bot PRs will be more common for this app than for tag-tracked ones. That's the cost of tracking a moving target, and was an explicit design choice in the upstream schema. If it gets noisy, we can either drop vanilla-klipper to a `github-release` tracking the latest tag (currently `v0.13.0`) or add a "min commit age" gate to the bot.

## Catalog UI

After merge, the Rinkhals Web catalog card for Klipper (vanilla) flips from `Upstream: b7c0329f  BUNDLED IS BEHIND` (coral) to `Upstream: b7c0329f` (faint, no pill). The manifest version it displays matches the bundled binary.