### PR TITLE
feat(catalog): drop 'advanced' on qr-typed properties

### DIFF
--- a/apps/octoeverywhere/app.json
+++ b/apps/octoeverywhere/app.json
@@ -17,8 +17,7 @@
     "properties": {
         "printer_link": {
             "display": "Link your printer",
-            "type": "qr",
-            "advanced": true
+            "type": "qr"
         }
     }
 }

--- a/apps/tailscale/app.json
+++ b/apps/tailscale/app.json
@@ -20,8 +20,7 @@
     "properties": {
         "account_login": {
             "display": "Connect to Tailscale",
-            "type": "qr",
-            "advanced": true
+            "type": "qr"
         }
     }
 }


### PR DESCRIPTION
## Summary

`account_login` (Tailscale) and `printer_link` (OctoEverywhere) were marked `"advanced": true` in `20260531_01` as a workaround for the Rinkhals Web portal rendering `qr`-typed properties as a useless text input. The portal now ships a real client-side QR code renderer in its Configure drawer:

- `qr`-typed properties display the URL as a scannable QR code (canvas-rendered, ~25 KB `qrcode` lib in the portal bundle, no backend round-trip).
- The raw URL is shown below the code as a copyable link.
- Empty state ("Waiting for the app to publish its login URL...") shows when the app is running but hasn't emitted a value yet; "Start the app to receive a login URL" shows when stopped.
- The portal's install-time `appNeedsConfiguration()` check now skips `qr` properties (they're output-only, not user input), so dropping `advanced: true` here doesn't regress the auto-enable flow on install.

That makes these properties first-class first-run interactions again, which is what they always were on the front-panel UI.

## What changes

```diff
 "account_login": {
   "display": "Connect to Tailscale",
-  "type": "qr",
-  "advanced": true
+  "type": "qr"
 }
```

```diff
 "printer_link": {
   "display": "Link your printer",
-  "type": "qr",
-  "advanced": true
+  "type": "qr"
 }
```

## Impact

- **Rinkhals Web portal**: the Tailscale and OctoEverywhere Configure buttons show by default (no need to enable "Advanced"). Clicking opens the drawer with a live QR code, no scrolling-to-hidden-checkbox required.
- **Front-panel UI**: unaffected. It never honored the `advanced` flag and continues to render the QR property as before.
- **Catalog auto-bump bot**: unaffected. This change is purely in the property declarations.

Pairs with a corresponding commit in `rinkhals-community/Rinkhals` on the `feature/rinkhals_web` branch (the portal's QR renderer + backend `appNeedsConfiguration` tweak). The two changes are independent: the portal change is harmless against the current advanced-marked manifests (it would render the QR if the user opted in via the Advanced toggle); this PR is what makes the new UI discoverable by default.