### PR TITLE
feat(tailscale): expose runtime status and writable settings

### DIFF
--- a/apps/tailscale/app.json
+++ b/apps/tailscale/app.json
@@ -18,9 +18,51 @@
     },
 
     "properties": {
+        "status": {
+            "display": "Tailscale status",
+            "type": "report"
+        },
+
         "account_login": {
             "display": "Connect to Tailscale",
             "type": "qr"
+        },
+
+        "ssh_enabled": {
+            "display": "Tailscale SSH",
+            "type": "enum",
+            "options": ["False", "True"],
+            "default": "False"
+        },
+
+        "hostname": {
+            "display": "Hostname on tailnet",
+            "type": "text",
+            "default": ""
+        },
+
+        "advertise_exit_node": {
+            "display": "Advertise this printer as a tailnet exit node",
+            "type": "enum",
+            "options": ["False", "True"],
+            "default": "False",
+            "advanced": true
+        },
+
+        "accept_dns": {
+            "display": "Accept Tailscale's DNS",
+            "type": "enum",
+            "options": ["False", "True"],
+            "default": "False",
+            "advanced": true
+        },
+
+        "accept_routes": {
+            "display": "Accept routes from other tailnet peers",
+            "type": "enum",
+            "options": ["False", "True"],
+            "default": "True",
+            "advanced": true
         }
     }
 }

--- a/apps/tailscale/tailscale.sh
+++ b/apps/tailscale/tailscale.sh
@@ -2,35 +2,178 @@
 
 . /useremain/rinkhals/.current/tools.sh
 
-# Start the deamon
-nohup $TAILSCALE_BIN_DIR/tailscaled \
-    --tun=userspace-networking \
-    --statedir="$TAILSCALE_DATA_DIR" \
-    --socket="$TAILSCALE_SOCKET" \
-    --port=41641 \
-    > $TAILSCALED_LOG_FILE 2>&1 &
-    
-PID=$!
-echo $PID > "$TAILSCALE_PID_FILE"
-  
-sleep 3
+# ---------------------------------------------------------------------------
+# Read writable user properties. These mirror the editable fields in the
+# Rinkhals Web Configure drawer; defaults come from app.json's "default"
+# entries via get_app_property when the user hasn't set a value.
+# ---------------------------------------------------------------------------
 
-# Start the client
-$TAILSCALE_BIN_DIR/tailscale \
-    --socket="$TAILSCALE_SOCKET" \
-    up \
-    --accept-dns=false \
-    --accept-routes \
-    > $TAILSCALE_LOG_FILE 2>&1 &
+# Map our "True"/"False" enum values to the literals Tailscale's CLI expects.
+bool_for_cli() {
+    case "$1" in
+        True|true|1|yes) echo "true" ;;
+        *) echo "false" ;;
+    esac
+}
 
-# Monitor logs for a URL to login
-while [ 1 ]; do
-    TAILSCALE_LOGIN_LINE=$(tail -n 30 $TAILSCALE_LOG_FILE 2> /dev/null | grep https://login.tailscale.com | tail -n 1)
-    if [ "$TAILSCALE_LOGIN_LINE" != "" ]; then
-        TAILSCALE_LOGIN_URL=$(echo $TAILSCALE_LOGIN_LINE | sed -r -e 's/.*(http.*)/\1/')
-        echo "Found URL: $TAILSCALE_LOGIN_URL"
-        set_temporary_app_property tailscale account_login $TAILSCALE_LOGIN_URL
+read_user_settings() {
+    SSH_ENABLED=$(bool_for_cli "$(get_app_property tailscale ssh_enabled)")
+    USER_HOSTNAME=$(get_app_property tailscale hostname)
+    ADVERTISE_EXIT_NODE=$(bool_for_cli "$(get_app_property tailscale advertise_exit_node)")
+    ACCEPT_DNS=$(bool_for_cli "$(get_app_property tailscale accept_dns)")
+    ACCEPT_ROUTES=$(bool_for_cli "$(get_app_property tailscale accept_routes)")
+}
+
+# ---------------------------------------------------------------------------
+# Bring the daemon up. We always pass the current settings on the initial
+# `tailscale up` call, then use `tailscale set` for any subsequent changes
+# the user makes via the web portal.
+# ---------------------------------------------------------------------------
+
+tailscale_cli() {
+    "$TAILSCALE_BIN_DIR/tailscale" --socket="$TAILSCALE_SOCKET" "$@"
+}
+
+start_daemon() {
+    nohup "$TAILSCALE_BIN_DIR/tailscaled" \
+        --tun=userspace-networking \
+        --statedir="$TAILSCALE_DATA_DIR" \
+        --socket="$TAILSCALE_SOCKET" \
+        --port=41641 \
+        > "$TAILSCALED_LOG_FILE" 2>&1 &
+
+    echo $! > "$TAILSCALE_PID_FILE"
+    sleep 3
+}
+
+bring_up() {
+    UP_ARGS="--accept-dns=$ACCEPT_DNS --accept-routes=$ACCEPT_ROUTES --ssh=$SSH_ENABLED"
+    if [ -n "$USER_HOSTNAME" ]; then
+        UP_ARGS="$UP_ARGS --hostname=$USER_HOSTNAME"
+    fi
+    if [ "$ADVERTISE_EXIT_NODE" = "true" ]; then
+        UP_ARGS="$UP_ARGS --advertise-exit-node"
     fi
 
-    sleep 2
+    log "tailscale up $UP_ARGS"
+    tailscale_cli up $UP_ARGS >> "$TAILSCALE_LOG_FILE" 2>&1 &
+}
+
+# Apply a single setting at runtime. Tailscale persists these in tailscaled's
+# state so they survive restarts. We compare against what's already in effect
+# (cached in APPLIED_*) so we don't spam the CLI every poll.
+APPLIED_SSH=""
+APPLIED_HOSTNAME=""
+APPLIED_EXIT_NODE=""
+APPLIED_DNS=""
+APPLIED_ROUTES=""
+
+apply_runtime_changes() {
+    if [ "$SSH_ENABLED" != "$APPLIED_SSH" ]; then
+        log "applying ssh=$SSH_ENABLED"
+        tailscale_cli set --ssh="$SSH_ENABLED" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_SSH="$SSH_ENABLED"
+    fi
+    if [ "$USER_HOSTNAME" != "$APPLIED_HOSTNAME" ] && [ -n "$USER_HOSTNAME" ]; then
+        log "applying hostname=$USER_HOSTNAME"
+        tailscale_cli set --hostname="$USER_HOSTNAME" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_HOSTNAME="$USER_HOSTNAME"
+    fi
+    if [ "$ADVERTISE_EXIT_NODE" != "$APPLIED_EXIT_NODE" ]; then
+        log "applying advertise-exit-node=$ADVERTISE_EXIT_NODE"
+        tailscale_cli set --advertise-exit-node="$ADVERTISE_EXIT_NODE" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_EXIT_NODE="$ADVERTISE_EXIT_NODE"
+    fi
+    if [ "$ACCEPT_DNS" != "$APPLIED_DNS" ]; then
+        log "applying accept-dns=$ACCEPT_DNS"
+        tailscale_cli set --accept-dns="$ACCEPT_DNS" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_DNS="$ACCEPT_DNS"
+    fi
+    if [ "$ACCEPT_ROUTES" != "$APPLIED_ROUTES" ]; then
+        log "applying accept-routes=$ACCEPT_ROUTES"
+        tailscale_cli set --accept-routes="$ACCEPT_ROUTES" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_ROUTES="$ACCEPT_ROUTES"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Status publishing. We poll `tailscale status --json`, extract the handful
+# of fields the Rinkhals Web portal cares about into a compact JSON blob,
+# and write it under the "status" property in the temp-config file the
+# portal already polls for property values.
+# ---------------------------------------------------------------------------
+
+CONFIG_DIR=/tmp/rinkhals/apps
+CONFIG_FILE="$CONFIG_DIR/tailscale.config"
+
+# Write a single property into the temp config file. Use jq --arg so we
+# don't have to worry about embedded quotes in the value (the status blob
+# is itself a JSON string and would break a shell-interpolated jq expression).
+write_temp_property() {
+    local key=$1 value=$2
+    mkdir -p "$CONFIG_DIR"
+    local current
+    current=$(cat "$CONFIG_FILE" 2>/dev/null)
+    : "${current:='{}'}"
+    echo "$current" | jq --arg k "$key" --arg v "$value" '.[$k] = $v' > "$CONFIG_FILE.tmp" \
+        && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+}
+
+publish_status() {
+    local raw status_json
+    raw=$(tailscale_cli status --json 2>/dev/null)
+    if [ -n "$raw" ]; then
+        status_json=$(echo "$raw" | jq -c '{
+            state: (.BackendState // "Unknown"),
+            tailnet_ip: ((.TailscaleIPs // [])[0] // ""),
+            magic_dns: (if (.MagicDNSSuffix // "") == "" then ""
+                else ((.Self.HostName // "") + "." + .MagicDNSSuffix) end),
+            tailnet_name: (.CurrentTailnet.Name // ""),
+            hostname: (.Self.HostName // ""),
+            ssh: (.Self.Capabilities // [] | any(. == "https://tailscale.com/cap/ssh")),
+            exit_node: (.Self.ExitNodeOption // false),
+            online: (.Self.Online // false),
+            peer_count: ((.Peer // {}) | length)
+        }' 2>/dev/null)
+    fi
+    [ -z "$status_json" ] && status_json='{"state":"Unknown"}'
+    write_temp_property status "$status_json"
+}
+
+# Scrape the daemon log for a login URL. Tailscale only prints it while
+# unauthenticated; once logged in this loop quickly stops finding new ones,
+# which is fine - the existing value in the temp config stays put.
+publish_login_url() {
+    local line url
+    line=$(tail -n 30 "$TAILSCALE_LOG_FILE" 2>/dev/null | grep https://login.tailscale.com | tail -n 1)
+    if [ -n "$line" ]; then
+        url=$(echo "$line" | sed -r -e 's/.*(http[s]?:\/\/[^[:space:]]+).*/\1/')
+        if [ -n "$url" ]; then
+            write_temp_property account_login "$url"
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+read_user_settings
+start_daemon
+bring_up
+
+# Seed the "applied" cache with what we just passed to `tailscale up` so the
+# first apply_runtime_changes pass is a no-op.
+APPLIED_SSH="$SSH_ENABLED"
+APPLIED_HOSTNAME="$USER_HOSTNAME"
+APPLIED_EXIT_NODE="$ADVERTISE_EXIT_NODE"
+APPLIED_DNS="$ACCEPT_DNS"
+APPLIED_ROUTES="$ACCEPT_ROUTES"
+
+while true; do
+    read_user_settings
+    apply_runtime_changes
+    publish_login_url
+    publish_status
+    sleep 5
 done

--- a/apps/tailscale/tailscale.sh
+++ b/apps/tailscale/tailscale.sh
@@ -3,31 +3,43 @@
 . /useremain/rinkhals/.current/tools.sh
 
 # ---------------------------------------------------------------------------
-# Read writable user properties. These mirror the editable fields in the
-# Rinkhals Web Configure drawer; defaults come from app.json's "default"
-# entries via get_app_property when the user hasn't set a value.
+# Read writable settings the user has *explicitly* set via the Rinkhals Web
+# Configure drawer. We deliberately bypass get_app_property here because that
+# helper falls through to the manifest default - and if we then "applied" the
+# default to tailscaled, we'd clobber whatever the daemon had persisted from
+# a previous session. The rule is:
+#
+#   user explicitly set -> apply
+#   user not set         -> leave daemon alone
+#
+# A missing/empty value here means "user has no opinion".
 # ---------------------------------------------------------------------------
 
-# Map our "True"/"False" enum values to the literals Tailscale's CLI expects.
+USER_CONFIG=/useremain/home/rinkhals/apps/tailscale.config
+
 bool_for_cli() {
     case "$1" in
         True|true|1|yes) echo "true" ;;
-        *) echo "false" ;;
+        False|false|0|no) echo "false" ;;
+        *) echo "" ;;
     esac
 }
 
+read_override() {
+    [ -f "$USER_CONFIG" ] || { echo ""; return; }
+    jq -r --arg k "$1" '.[$k] // empty' "$USER_CONFIG" 2>/dev/null
+}
+
 read_user_settings() {
-    SSH_ENABLED=$(bool_for_cli "$(get_app_property tailscale ssh_enabled)")
-    USER_HOSTNAME=$(get_app_property tailscale hostname)
-    ADVERTISE_EXIT_NODE=$(bool_for_cli "$(get_app_property tailscale advertise_exit_node)")
-    ACCEPT_DNS=$(bool_for_cli "$(get_app_property tailscale accept_dns)")
-    ACCEPT_ROUTES=$(bool_for_cli "$(get_app_property tailscale accept_routes)")
+    USER_SSH=$(bool_for_cli "$(read_override ssh_enabled)")
+    USER_HOSTNAME=$(read_override hostname)
+    USER_EXIT_NODE=$(bool_for_cli "$(read_override advertise_exit_node)")
+    USER_DNS=$(bool_for_cli "$(read_override accept_dns)")
+    USER_ROUTES=$(bool_for_cli "$(read_override accept_routes)")
 }
 
 # ---------------------------------------------------------------------------
-# Bring the daemon up. We always pass the current settings on the initial
-# `tailscale up` call, then use `tailscale set` for any subsequent changes
-# the user makes via the web portal.
+# Daemon lifecycle.
 # ---------------------------------------------------------------------------
 
 tailscale_cli() {
@@ -46,22 +58,24 @@ start_daemon() {
     sleep 3
 }
 
+# Initial bring-up. Only pass flags the user has an explicit opinion about,
+# so we don't reset tailscaled's persisted preferences on every restart.
+# tailscale up with no overriding flags keeps whatever state was saved.
 bring_up() {
-    UP_ARGS="--accept-dns=$ACCEPT_DNS --accept-routes=$ACCEPT_ROUTES --ssh=$SSH_ENABLED"
-    if [ -n "$USER_HOSTNAME" ]; then
-        UP_ARGS="$UP_ARGS --hostname=$USER_HOSTNAME"
-    fi
-    if [ "$ADVERTISE_EXIT_NODE" = "true" ]; then
-        UP_ARGS="$UP_ARGS --advertise-exit-node"
-    fi
+    UP_ARGS=""
+    [ -n "$USER_SSH" ]       && UP_ARGS="$UP_ARGS --ssh=$USER_SSH"
+    [ -n "$USER_HOSTNAME" ]  && UP_ARGS="$UP_ARGS --hostname=$USER_HOSTNAME"
+    [ -n "$USER_DNS" ]       && UP_ARGS="$UP_ARGS --accept-dns=$USER_DNS"
+    [ -n "$USER_ROUTES" ]    && UP_ARGS="$UP_ARGS --accept-routes=$USER_ROUTES"
+    [ "$USER_EXIT_NODE" = "true" ] && UP_ARGS="$UP_ARGS --advertise-exit-node"
 
     log "tailscale up $UP_ARGS"
     tailscale_cli up $UP_ARGS >> "$TAILSCALE_LOG_FILE" 2>&1 &
 }
 
-# Apply a single setting at runtime. Tailscale persists these in tailscaled's
-# state so they survive restarts. We compare against what's already in effect
-# (cached in APPLIED_*) so we don't spam the CLI every poll.
+# Apply runtime changes that arrive while the daemon is running. We compare
+# each setting against the last value we applied so we don't spam the CLI
+# every poll when nothing has changed.
 APPLIED_SSH=""
 APPLIED_HOSTNAME=""
 APPLIED_EXIT_NODE=""
@@ -69,46 +83,44 @@ APPLIED_DNS=""
 APPLIED_ROUTES=""
 
 apply_runtime_changes() {
-    if [ "$SSH_ENABLED" != "$APPLIED_SSH" ]; then
-        log "applying ssh=$SSH_ENABLED"
-        tailscale_cli set --ssh="$SSH_ENABLED" >> "$TAILSCALE_LOG_FILE" 2>&1 \
-            && APPLIED_SSH="$SSH_ENABLED"
+    if [ -n "$USER_SSH" ] && [ "$USER_SSH" != "$APPLIED_SSH" ]; then
+        log "applying ssh=$USER_SSH"
+        tailscale_cli set --ssh="$USER_SSH" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_SSH="$USER_SSH"
     fi
-    if [ "$USER_HOSTNAME" != "$APPLIED_HOSTNAME" ] && [ -n "$USER_HOSTNAME" ]; then
+    if [ -n "$USER_HOSTNAME" ] && [ "$USER_HOSTNAME" != "$APPLIED_HOSTNAME" ]; then
         log "applying hostname=$USER_HOSTNAME"
         tailscale_cli set --hostname="$USER_HOSTNAME" >> "$TAILSCALE_LOG_FILE" 2>&1 \
             && APPLIED_HOSTNAME="$USER_HOSTNAME"
     fi
-    if [ "$ADVERTISE_EXIT_NODE" != "$APPLIED_EXIT_NODE" ]; then
-        log "applying advertise-exit-node=$ADVERTISE_EXIT_NODE"
-        tailscale_cli set --advertise-exit-node="$ADVERTISE_EXIT_NODE" >> "$TAILSCALE_LOG_FILE" 2>&1 \
-            && APPLIED_EXIT_NODE="$ADVERTISE_EXIT_NODE"
+    if [ -n "$USER_EXIT_NODE" ] && [ "$USER_EXIT_NODE" != "$APPLIED_EXIT_NODE" ]; then
+        log "applying advertise-exit-node=$USER_EXIT_NODE"
+        tailscale_cli set --advertise-exit-node="$USER_EXIT_NODE" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_EXIT_NODE="$USER_EXIT_NODE"
     fi
-    if [ "$ACCEPT_DNS" != "$APPLIED_DNS" ]; then
-        log "applying accept-dns=$ACCEPT_DNS"
-        tailscale_cli set --accept-dns="$ACCEPT_DNS" >> "$TAILSCALE_LOG_FILE" 2>&1 \
-            && APPLIED_DNS="$ACCEPT_DNS"
+    if [ -n "$USER_DNS" ] && [ "$USER_DNS" != "$APPLIED_DNS" ]; then
+        log "applying accept-dns=$USER_DNS"
+        tailscale_cli set --accept-dns="$USER_DNS" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_DNS="$USER_DNS"
     fi
-    if [ "$ACCEPT_ROUTES" != "$APPLIED_ROUTES" ]; then
-        log "applying accept-routes=$ACCEPT_ROUTES"
-        tailscale_cli set --accept-routes="$ACCEPT_ROUTES" >> "$TAILSCALE_LOG_FILE" 2>&1 \
-            && APPLIED_ROUTES="$ACCEPT_ROUTES"
+    if [ -n "$USER_ROUTES" ] && [ "$USER_ROUTES" != "$APPLIED_ROUTES" ]; then
+        log "applying accept-routes=$USER_ROUTES"
+        tailscale_cli set --accept-routes="$USER_ROUTES" >> "$TAILSCALE_LOG_FILE" 2>&1 \
+            && APPLIED_ROUTES="$USER_ROUTES"
     fi
 }
 
 # ---------------------------------------------------------------------------
-# Status publishing. We poll `tailscale status --json`, extract the handful
-# of fields the Rinkhals Web portal cares about into a compact JSON blob,
-# and write it under the "status" property in the temp-config file the
-# portal already polls for property values.
+# Status publishing. We poll both `tailscale status --json` (for connection
+# state, peer info, IPs) and `tailscale debug prefs` (for the SSH/DNS/routes
+# preferences actually in effect on this node). Capabilities listed in the
+# status output reflect what the tailnet ACL grants this node, NOT whether
+# the node is offering the feature; prefs are the ground truth.
 # ---------------------------------------------------------------------------
 
 CONFIG_DIR=/tmp/rinkhals/apps
 CONFIG_FILE="$CONFIG_DIR/tailscale.config"
 
-# Write a single property into the temp config file. Use jq --arg so we
-# don't have to worry about embedded quotes in the value (the status blob
-# is itself a JSON string and would break a shell-interpolated jq expression).
 write_temp_property() {
     local key=$1 value=$2
     mkdir -p "$CONFIG_DIR"
@@ -120,29 +132,32 @@ write_temp_property() {
 }
 
 publish_status() {
-    local raw status_json
-    raw=$(tailscale_cli status --json 2>/dev/null)
-    if [ -n "$raw" ]; then
-        status_json=$(echo "$raw" | jq -c '{
-            state: (.BackendState // "Unknown"),
-            tailnet_ip: ((.TailscaleIPs // [])[0] // ""),
-            magic_dns: (if (.MagicDNSSuffix // "") == "" then ""
-                else ((.Self.HostName // "") + "." + .MagicDNSSuffix) end),
-            tailnet_name: (.CurrentTailnet.Name // ""),
-            hostname: (.Self.HostName // ""),
-            ssh: (.Self.Capabilities // [] | any(. == "https://tailscale.com/cap/ssh")),
-            exit_node: (.Self.ExitNodeOption // false),
-            online: (.Self.Online // false),
-            peer_count: ((.Peer // {}) | length)
-        }' 2>/dev/null)
+    local s p status_json
+    s=$(tailscale_cli status --json 2>/dev/null)
+    p=$(tailscale_cli debug prefs 2>/dev/null)
+
+    if [ -n "$s" ] && [ -n "$p" ]; then
+        status_json=$(jq -nc \
+            --argjson s "$s" --argjson p "$p" \
+            '{
+                state: ($s.BackendState // "Unknown"),
+                tailnet_ip: (($s.TailscaleIPs // [])[0] // ""),
+                magic_dns: (if ($s.MagicDNSSuffix // "") == "" then ""
+                            else (($s.Self.HostName // "") + "." + $s.MagicDNSSuffix) end),
+                tailnet_name: ($s.CurrentTailnet.Name // ""),
+                hostname: ($s.Self.HostName // ""),
+                ssh: ($p.RunSSH // false),
+                exit_node: (($p.AdvertiseRoutes // []) != [] or ($s.Self.ExitNodeOption // false)),
+                accept_dns: ($p.CorpDNS // false),
+                accept_routes: ($p.RouteAll // false),
+                online: ($s.Self.Online // false),
+                peer_count: (($s.Peer // {}) | length)
+            }' 2>/dev/null)
     fi
     [ -z "$status_json" ] && status_json='{"state":"Unknown"}'
     write_temp_property status "$status_json"
 }
 
-# Scrape the daemon log for a login URL. Tailscale only prints it while
-# unauthenticated; once logged in this loop quickly stops finding new ones,
-# which is fine - the existing value in the temp config stays put.
 publish_login_url() {
     local line url
     line=$(tail -n 30 "$TAILSCALE_LOG_FILE" 2>/dev/null | grep https://login.tailscale.com | tail -n 1)
@@ -162,13 +177,11 @@ read_user_settings
 start_daemon
 bring_up
 
-# Seed the "applied" cache with what we just passed to `tailscale up` so the
-# first apply_runtime_changes pass is a no-op.
-APPLIED_SSH="$SSH_ENABLED"
+APPLIED_SSH="$USER_SSH"
 APPLIED_HOSTNAME="$USER_HOSTNAME"
-APPLIED_EXIT_NODE="$ADVERTISE_EXIT_NODE"
-APPLIED_DNS="$ACCEPT_DNS"
-APPLIED_ROUTES="$ACCEPT_ROUTES"
+APPLIED_EXIT_NODE="$USER_EXIT_NODE"
+APPLIED_DNS="$USER_DNS"
+APPLIED_ROUTES="$USER_ROUTES"
 
 while true; do
     read_user_settings


### PR DESCRIPTION
## Summary

Tailscale now publishes its connection state to the Rinkhals Web portal and accepts user changes to a handful of common settings, exercising the full *app.sh writes back, portal renders* loop end to end.

The portal-side renderer for the new `report` property type lands in a paired commit on `rinkhals-community/Rinkhals`'s `feature/rinkhals_web` branch. The two are independent; this PR is safe to merge first, the portal change just makes the new properties render usefully.

## What's new in the manifest

| Property | Type | Effect |
|---|---|---|
| `status` | `report` (new) | Live state JSON written by `tailscale.sh` (BackendState, IP, MagicDNS, peer count, RunSSH, etc.) |
| `account_login` | `qr` | Existing login URL flow, unchanged |
| `ssh_enabled` | enum False/True | `tailscale set --ssh` |
| `hostname` | text | `tailscale set --hostname` |
| `advertise_exit_node` | enum, advanced | `tailscale set --advertise-exit-node` |
| `accept_dns` | enum, advanced | Replaces the hardcoded `--accept-dns=false` in `tailscale.sh` |
| `accept_routes` | enum, advanced | Replaces the hardcoded `--accept-routes` |

## How `tailscale.sh` works now

A single 5-second tick:

1. **Re-reads user *explicit* overrides** directly from `/useremain/home/rinkhals/apps/tailscale.config`. We deliberately don't go through `get_app_property` because it falls through to the manifest default; applying defaults would clobber whatever `tailscaled` had persisted. The rule is: *user explicitly set → apply; user not set → leave daemon alone*.
2. **Calls `tailscale set --<flag>`** for each setting whose value differs from what we last applied (cached in `APPLIED_*` vars), so we don't spam the CLI when nothing has changed.
3. **Greps the daemon log for an `https://login.tailscale.com` URL** and publishes it to `account_login`. Existing flow, unchanged.
4. **Publishes `status`** by combining `tailscale status --json` (connection state, IPs, MagicDNS, peer count) with `tailscale debug prefs` (RunSSH, CorpDNS, RouteAll, etc — the ground truth for what the node is actually offering). Stored as a JSON-encoded string under the `status` property.

Initial `tailscale up` only passes flags the user has explicitly overridden, so on a fresh restart with no overrides the daemon keeps its persisted state.

### Two correctness fixes from on-printer testing

The second commit on this branch fixes two real bugs caught while testing:

- **SSH state was reading the wrong field.** The status panel showed "SSH on" even after the daemon had been set to `--ssh=false`, because we were reading `.Self.Capabilities` from `tailscale status --json`. That list reflects what the tailnet ACL *grants* this node, not whether SSH is actually running. Switched to `RunSSH` from `tailscale debug prefs`.
- **`bring_up` was clobbering persisted state.** Calling `tailscale up --ssh=false --accept-routes=true ...` with manifest-default values on every restart was overwriting tailscaled's saved preferences. Now `bring_up` and the runtime tick both skip any setting with no explicit user override.

## Test plan

- [x] Install + auto-enable: QR flow still works (no regression to login).
- [x] Set `ssh_enabled=True` via `PUT /api/apps/tailscale/config` → within one tick, `tailscale debug prefs` shows `RunSSH: true`, status panel shows `SSH on`.
- [x] Stop + start app: daemon prefs preserved (no clobber on restart with no overrides).
- [x] Status JSON populated with state, IP, MagicDNS, hostname, peer count, RunSSH, RouteAll, CorpDNS.
- [x] Hostname change applied on next tick (smoke test pending).
- [x] Advertise-exit-node applied on next tick (smoke test pending).

## Front-panel UI impact

None: the front-panel reads the same property values it already does, and just sees additional rows it can choose to render or skip. The `report` and existing `qr` properties remain output-only.