### PR TITLE
fix(tailscale): preserve old accept_dns/accept_routes defaults on bring_up

### DIFF
--- a/apps/tailscale/tailscale.sh
+++ b/apps/tailscale/tailscale.sh
@@ -58,15 +58,23 @@ start_daemon() {
     sleep 3
 }
 
-# Initial bring-up. Only pass flags the user has an explicit opinion about,
-# so we don't reset tailscaled's persisted preferences on every restart.
-# tailscale up with no overriding flags keeps whatever state was saved.
+# Manifest defaults for accept_dns / accept_routes. We always apply these on
+# bring_up because the original tailscale.sh hardcoded them, and front-panel
+# users who never touch the Rinkhals Web portal would otherwise silently
+# regress (Tailscale's built-in default for accept_routes is false, which
+# breaks subnet-routing scenarios that worked before). The other new
+# settings (ssh, hostname, advertise_exit_node) only apply on explicit user
+# override, because tailscaled's persisted preference is the right fallback
+# when the user has no opinion.
+DEFAULT_ACCEPT_DNS=false
+DEFAULT_ACCEPT_ROUTES=true
+
 bring_up() {
     UP_ARGS=""
     [ -n "$USER_SSH" ]       && UP_ARGS="$UP_ARGS --ssh=$USER_SSH"
     [ -n "$USER_HOSTNAME" ]  && UP_ARGS="$UP_ARGS --hostname=$USER_HOSTNAME"
-    [ -n "$USER_DNS" ]       && UP_ARGS="$UP_ARGS --accept-dns=$USER_DNS"
-    [ -n "$USER_ROUTES" ]    && UP_ARGS="$UP_ARGS --accept-routes=$USER_ROUTES"
+    UP_ARGS="$UP_ARGS --accept-dns=${USER_DNS:-$DEFAULT_ACCEPT_DNS}"
+    UP_ARGS="$UP_ARGS --accept-routes=${USER_ROUTES:-$DEFAULT_ACCEPT_ROUTES}"
     [ "$USER_EXIT_NODE" = "true" ] && UP_ARGS="$UP_ARGS --advertise-exit-node"
 
     log "tailscale up $UP_ARGS"


### PR DESCRIPTION
## Summary

Closes a subtle regression introduced by #6 that affects front-panel-only users.

The pre-#6 `tailscale.sh` hardcoded `tailscale up --accept-dns=false --accept-routes` on every restart. PR #6 moved to a strict "only pass flags the user explicitly set via the Rinkhals Web portal" rule so daemon-persisted preferences wouldn't get clobbered. That's right for the truly new fields (`ssh_enabled`, `hostname`, `advertise_exit_node`) — but it silently regressed the two formerly-hardcoded defaults.

Tailscale's built-in default for `accept-routes` is `false`, so a front-panel user with subnet-routing scenarios that used to work would silently stop receiving routes from tailnet peers after upgrading. They have no way to fix this because the front-panel UI doesn't render generic property editors (it only knows about `qr` properties).

## What changes

Split the two policies cleanly:

| Setting | Policy on bring_up |
|---|---|
| `accept_dns` | Always passed: `--accept-dns=${USER_DNS:-false}` (manifest default `false`) |
| `accept_routes` | Always passed: `--accept-routes=${USER_ROUTES:-true}` (manifest default `true`) |
| `ssh_enabled` | Pass `--ssh=$USER_SSH` only when the user has an explicit override |
| `hostname` | Pass `--hostname=$USER_HOSTNAME` only when the user has an explicit override |
| `advertise_exit_node` | Pass `--advertise-exit-node` only when user has set it to True |

`DEFAULT_ACCEPT_DNS=false` and `DEFAULT_ACCEPT_ROUTES=true` mirror the pre-#6 hardcoded values exactly, so front-panel users see no behavior change.

## Verified on KS1

With the user config cleared to `{}` (no overrides at all), the script now logs:

```
tailscale up  --accept-dns=false --accept-routes=true
```

and tailscaled's pre-existing prefs survive the restart:

```json
{ "RunSSH": true, "CorpDNS": false, "RouteAll": true, "Hostname": "" }
```

`RunSSH: true` was set earlier by an explicit portal override that was then cleared — the cleared override doesn't reset the daemon, exactly as intended. `RouteAll: true` reflects the manifest default being applied. `CorpDNS: false` likewise.

## Why I'm not seeding the persistent config on first install instead

That was the alternative: have `app.sh` write the manifest defaults into the user config on first launch so future bring_ups always see explicit user values. Rejected because:

- It blurs the meaning of "user override". A value seeded by the installer would look the same as a value the user actively chose, breaking the "Reset" semantics in the portal.
- "Clear all overrides" in the portal would behave differently depending on whether the file was seeded, which is confusing.

The two-policy approach here keeps "user override = user said so" as the source-of-truth contract.

## Front-panel impact

Same as before: only the `qr`-typed property is rendered (the login QR). The new properties remain invisible on the touch screen, and that's fine. This PR just ensures the *effective* Tailscale configuration matches what a front-panel-only user got pre-#6.