### PR TITLE
fix(cloud2lan-bridge): supervise + wait for boot deps + reconnect handling

### DIFF
--- a/apps/cloud2lan-bridge/app.sh
+++ b/apps/cloud2lan-bridge/app.sh
@@ -13,11 +13,15 @@ status() {
 }
 start() {
     stop
-    
+
     cd $APP_ROOT
-    python ./cloud2lan-bridge.py &
+
+    chmod +x cloud2lan-bridge.sh
+    ./cloud2lan-bridge.sh &
 }
 stop() {
+    # Kill the supervisor first so it doesn't immediately respawn the python.
+    kill_by_name cloud2lan-bridge.sh
     kill_by_name cloud2lan-bridge.py
 }
 

--- a/apps/cloud2lan-bridge/app.sh
+++ b/apps/cloud2lan-bridge/app.sh
@@ -17,7 +17,13 @@ start() {
     cd $APP_ROOT
 
     chmod +x cloud2lan-bridge.sh
-    ./cloud2lan-bridge.sh &
+    # Detach stdin/stdout/stderr from /dev/null. cloud2lan-bridge.sh is a
+    # long-lived supervisor, so if it inherited this shell's fds it would hold
+    # them open. When start is invoked from the on-screen menu (rinkhals-ui.py),
+    # which captures the command's output through a pipe, that keeps the pipe's
+    # write end open and hangs the UI (a frozen touchscreen). The supervisor
+    # writes everything to app-cloud2lan-bridge.log.
+    ./cloud2lan-bridge.sh </dev/null >/dev/null 2>&1 &
 }
 stop() {
     # Kill the supervisor first so it doesn't immediately respawn the python.

--- a/apps/cloud2lan-bridge/cloud2lan-bridge.py
+++ b/apps/cloud2lan-bridge/cloud2lan-bridge.py
@@ -1,6 +1,7 @@
 import os
+import sys
+import socket
 import configparser
-import base64
 import subprocess
 import hashlib
 import json
@@ -19,7 +20,7 @@ LOG_INFO = 1
 LOG_WARNING = 2
 LOG_ERROR = 3
 
-LOG_LEVEL = LOG_DEBUG if not not os.getenv('DEBUG') else LOG_INFO
+LOG_LEVEL = LOG_DEBUG if os.getenv('DEBUG') else LOG_INFO
 
 
 def log(level, message):
@@ -29,6 +30,45 @@ def md5(input: str) -> str:
     return hashlib.md5(input.encode('utf-8')).hexdigest()
 def now() -> int:
     return round(time.time() * 1000)
+
+
+def wait_for_file(path: str, timeout: float = 120.0, poll_interval: float = 1.0) -> bool:
+    """
+    Block until `path` exists. Returns True if it appeared within `timeout`
+    seconds, False on timeout.
+
+    Apps can start before the stock Anycubic firmware has finished laying
+    down its config files in /userdata/app/gk/config and the boot-time
+    descriptors in /useremain/dev/. Reading them eagerly in __init__ races
+    that boot sequence and was the main reason cloud2lan-bridge "didn't
+    start sometimes."
+    """
+    deadline = time.time() + timeout
+    while not os.path.exists(path):
+        if time.time() >= deadline:
+            return False
+        time.sleep(poll_interval)
+    return True
+
+def wait_for_tcp(host: str, port: int, timeout: float = 120.0, poll_interval: float = 1.0) -> bool:
+    """
+    Block until host:port accepts a TCP connection. Returns True if reachable
+    within `timeout` seconds, False on timeout.
+
+    Used to gate the LAN MQTT connect on gklib's local broker actually being
+    up. Connecting before the broker has bound the port produces a
+    ConnectionRefusedError that, under the previous code, propagated out to
+    main() and SIGKILLed the process with no respawn.
+    """
+    deadline = time.time() + timeout
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=2.0):
+                return True
+        except (OSError, socket.timeout):
+            if time.time() >= deadline:
+                return False
+            time.sleep(poll_interval)
 
 
 class Program:
@@ -48,6 +88,21 @@ class Program:
     lan_client = None
 
     def __init__(self):
+        # Wait for the boot-time files we depend on. The stock Anycubic
+        # firmware writes these as part of its startup; if Rinkhals brings
+        # this app up before that's done, eager reads explode.
+        required_files = [
+            '/userdata/app/gk/config/device.ini',
+            '/userdata/app/gk/config/api.cfg',
+            '/userdata/app/gk/config/device_account.json',
+            '/useremain/dev/version',
+            '/useremain/dev/device_id',
+        ]
+        for path in required_files:
+            log(LOG_INFO, f'Waiting for {path}...')
+            if not wait_for_file(path, timeout=120):
+                raise RuntimeError(f'Timed out waiting for {path}')
+
         self.cloud_config = self.get_cloud_config()
         self.api_config = self.get_api_config()
 
@@ -79,7 +134,7 @@ class Program:
         cert_file = f'{cert_path}/deviceCrt'
         key_file = f'{cert_path}/devicePk'
         ca_file = f'{cert_path}/caCrt'
-        
+
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.set_ciphers(('ALL:@SECLEVEL=0'),)
         if cert_file and key_file:
@@ -126,7 +181,7 @@ class Program:
 
         response = topic.endswith('/response')
         report = topic.endswith('/report')
-        
+
         if not response:
             if report:
                 log(LOG_INFO, f'[{mode}] Sent report for {payload.get("type")}/{payload.get("action")}')
@@ -148,7 +203,7 @@ class Program:
             self.send_message(self.lan_client, topic.replace(self.cloud_device_id, self.lan_device_id), payload)
     def on_lan_message(self, topic, payload):
         log(LOG_DEBUG, f'[lan] Received {topic} = {str(payload)}')
- 
+
         if not topic.endswith('/response'):
             if topic.endswith('/report'):
                 log(LOG_INFO, f'[lan] Received report for {payload.get("type")}/{payload.get("action")}')
@@ -166,12 +221,21 @@ class Program:
             log(LOG_INFO, '[cloud] Connected')
             self.cloud_client.subscribe(f'anycubic/anycubicCloud/v1/+/printer/{self.model_id}/{self.cloud_device_id}/#')
         def mqtt_on_connect_fail(client, userdata):
-            log(LOG_INFO, '[cloud] Failed to connect')
+            log(LOG_WARNING, '[cloud] Failed to connect')
+        def mqtt_on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
+            log(LOG_WARNING, f'[cloud] Disconnected (reason: {reason_code}); paho will retry')
         def mqtt_on_log(client, userdata, level, buf):
             #log(LOG_DEBUG, buf)
             pass
         def mqtt_on_message(client, userdata, msg):
-            self.on_cloud_message(msg.topic, json.loads(msg.payload.decode("utf-8")))
+            # Wrap in try/except so a single malformed payload doesn't kill
+            # the callback path. paho catches the exception and continues,
+            # but the message is lost; logging it makes debugging tractable.
+            try:
+                payload = json.loads(msg.payload.decode("utf-8"))
+                self.on_cloud_message(msg.topic, payload)
+            except Exception as e:
+                log(LOG_ERROR, f'[cloud] Failed to handle {msg.topic}: {e}')
 
         mqtt_broker_endpoint = urllib.parse.urlparse(mqtt_broker)
 
@@ -184,28 +248,63 @@ class Program:
 
         self.cloud_client.on_connect = mqtt_on_connect
         self.cloud_client.on_connect_fail = mqtt_on_connect_fail
+        self.cloud_client.on_disconnect = mqtt_on_disconnect
         self.cloud_client.on_message = mqtt_on_message
         self.cloud_client.on_log = mqtt_on_log
 
         self.cloud_client.username_pw_set(mqtt_username, mqtt_password)
-        self.cloud_client.connect(mqtt_broker_endpoint.hostname, mqtt_broker_endpoint.port or 1883)
-        self.cloud_client.loop_start()
 
+        # Retry with exponential backoff. Network may not be up yet at boot,
+        # DNS may not be ready, the cert may not be loaded, etc. Fail loudly
+        # only after multiple attempts.
+        last_err = None
+        for attempt in range(8):
+            try:
+                self.cloud_client.connect(mqtt_broker_endpoint.hostname, mqtt_broker_endpoint.port or 1883)
+                self.cloud_client.loop_start()
+                break
+            except Exception as e:
+                last_err = e
+                wait = min(60, 2 ** attempt)
+                log(LOG_WARNING, f'[cloud] Connect attempt {attempt+1} failed: {e}; retrying in {wait}s')
+                time.sleep(wait)
+        else:
+            raise RuntimeError(f'Could not connect to cloud MQTT after 8 attempts: {last_err}')
+
+        # Bounded wait for CONNACK so we don't hang forever on a half-open
+        # connection where TCP completed but the broker never replied.
+        deadline = time.time() + 30
         while not self.cloud_client.is_connected():
+            if time.time() >= deadline:
+                raise RuntimeError('Cloud MQTT TCP connected but never got CONNACK')
             time.sleep(0.25)
     def connect_lan_mqtt(self):
+        # Wait for gklib's local broker to be reachable. This is by far the
+        # most common race at boot: the bridge starts in parallel with the
+        # Anycubic stack and gklib hasn't bound port 9883 yet.
+        log(LOG_INFO, '[lan] Waiting for local MQTT broker on 127.0.0.1:9883...')
+        if not wait_for_tcp('127.0.0.1', 9883, timeout=120):
+            raise RuntimeError('Timed out waiting for local MQTT broker (gklib not up?)')
+        log(LOG_INFO, '[lan] Local MQTT broker is reachable')
+
         mqtt_username, mqtt_password = self.get_lan_mqtt_credentials()
 
         def mqtt_on_connect(client, userdata, connect_flags, reason_code, properties):
             log(LOG_INFO, '[lan] Connected')
             self.lan_client.subscribe(f'anycubic/anycubicCloud/v1/printer/public/{self.model_id}/{self.lan_device_id}/#')
         def mqtt_on_connect_fail(client, userdata):
-            log(LOG_INFO, '[lan] Failed to connect')
+            log(LOG_WARNING, '[lan] Failed to connect')
+        def mqtt_on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
+            log(LOG_WARNING, f'[lan] Disconnected (reason: {reason_code}); paho will retry')
         def mqtt_on_log(client, userdata, level, buf):
             #log(LOG_DEBUG, buf)
             pass
         def mqtt_on_message(client, userdata, msg):
-            self.on_lan_message(msg.topic, json.loads(msg.payload.decode("utf-8")))
+            try:
+                payload = json.loads(msg.payload.decode("utf-8"))
+                self.on_lan_message(msg.topic, payload)
+            except Exception as e:
+                log(LOG_ERROR, f'[lan] Failed to handle {msg.topic}: {e}')
 
         self.lan_client = mqtt.Client(protocol=mqtt.MQTTv5, client_id=self.lan_device_id)
         self.lan_client.enable_logger()
@@ -215,16 +314,35 @@ class Program:
 
         self.lan_client.on_connect = mqtt_on_connect
         self.lan_client.on_connect_fail = mqtt_on_connect_fail
+        self.lan_client.on_disconnect = mqtt_on_disconnect
         self.lan_client.on_message = mqtt_on_message
         self.lan_client.on_log = mqtt_on_log
 
         self.lan_client.username_pw_set(mqtt_username, mqtt_password)
-        self.lan_client.connect('127.0.0.1', 9883)
-        self.lan_client.loop_start()
 
+        # Retry the actual connect even though we just confirmed the port
+        # is open. There's a small window where gklib has the TCP socket
+        # listening but isn't fully processing CONNECT packets yet.
+        last_err = None
+        for attempt in range(8):
+            try:
+                self.lan_client.connect('127.0.0.1', 9883)
+                self.lan_client.loop_start()
+                break
+            except Exception as e:
+                last_err = e
+                wait = min(60, 2 ** attempt)
+                log(LOG_WARNING, f'[lan] Connect attempt {attempt+1} failed: {e}; retrying in {wait}s')
+                time.sleep(wait)
+        else:
+            raise RuntimeError(f'Could not connect to local MQTT after 8 attempts: {last_err}')
+
+        deadline = time.time() + 30
         while not self.lan_client.is_connected():
+            if time.time() >= deadline:
+                raise RuntimeError('Local MQTT TCP connected but never got CONNACK')
             time.sleep(0.25)
-    
+
     def main(self):
 
         self.connect_cloud_mqtt()
@@ -272,8 +390,15 @@ class Program:
         }
         self.send_message(self.cloud_client, f'anycubic/anycubicCloud/v1/printer/public/{self.model_id}/{self.cloud_device_id}/ota/report', payload)
 
+        # Heartbeat loop. Logging the connection state every few minutes
+        # makes it possible to tell from the app log whether the bridge is
+        # actually alive and which side dropped if something stops working.
+        HEARTBEAT_INTERVAL = 300
         while True:
-            time.sleep(1)
+            time.sleep(HEARTBEAT_INTERVAL)
+            cloud_ok = self.cloud_client.is_connected() if self.cloud_client else False
+            lan_ok = self.lan_client.is_connected() if self.lan_client else False
+            log(LOG_INFO, f'[heartbeat] cloud={"up" if cloud_ok else "DOWN"} lan={"up" if lan_ok else "DOWN"}')
 
 
 if __name__ == "__main__":
@@ -283,4 +408,8 @@ if __name__ == "__main__":
     except Exception as e:
         log(LOG_ERROR, str(e))
         log(LOG_ERROR, traceback.format_exc())
-        os.kill(os.getpid(), 9)
+        # sys.exit so the supervisor wrapper sees a non-zero exit and
+        # respawns. The previous os.kill(SIGKILL) bypassed even our own
+        # atexit handlers and looked indistinguishable from an external
+        # kill - the supervisor couldn't tell whether to restart.
+        sys.exit(1)

--- a/apps/cloud2lan-bridge/cloud2lan-bridge.sh
+++ b/apps/cloud2lan-bridge/cloud2lan-bridge.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+. /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+LOG_FILE="${RINKHALS_LOGS:-/tmp/rinkhals}/app-cloud2lan-bridge.log"
+
+cd "$APP_ROOT"
+
+# Crash-loop-aware supervisor. Restarts the python script if it exits
+# non-zero, rate-limited so a fast crash loop doesn't burn CPU forever.
+# Modeled on moonraker.sh's start_moonraker_with_restart.
+start_with_restart() {
+    crash_count=0
+    crash_window_start=$(date +%s)
+    max_crashes=5
+    crash_window=300   # 5 minutes
+    cooldown=10
+
+    while true; do
+        # Reset the crash counter if we've been up for a while.
+        current_time=$(date +%s)
+        if [ $((current_time - crash_window_start)) -gt $crash_window ]; then
+            crash_count=0
+            crash_window_start=$current_time
+        fi
+
+        echo "$(date): Starting cloud2lan-bridge (crash count: $crash_count/$max_crashes)" >> "$LOG_FILE"
+        python ./cloud2lan-bridge.py >> "$LOG_FILE" 2>&1
+        exit_code=$?
+        echo "$(date): cloud2lan-bridge exited with code $exit_code" >> "$LOG_FILE"
+
+        # Exit code 0 = clean stop, don't respawn.
+        if [ $exit_code -eq 0 ]; then
+            echo "$(date): Clean shutdown, exiting supervisor" >> "$LOG_FILE"
+            break
+        fi
+
+        crash_count=$((crash_count + 1))
+        if [ $crash_count -ge $max_crashes ]; then
+            echo "$(date): Too many crashes ($crash_count) in ${crash_window}s, giving up" >> "$LOG_FILE"
+            break
+        fi
+
+        echo "$(date): Waiting ${cooldown}s before restart..." >> "$LOG_FILE"
+        sleep $cooldown
+    done
+}
+
+start_with_restart


### PR DESCRIPTION
A Reddit user reported the bridge is "not exactly stable, and seems not to start sometimes with the printer." Both symptoms have the same root cause: any exception during startup or main caused `os.kill(SIGKILL)` on self with no respawn, so a single race against the boot sequence killed the app permanently for that boot.

Changes:

* New `cloud2lan-bridge.sh` supervisor wrapper. Restarts the python script on non-zero exit, rate-limited (max 5 crashes per 5 minutes, 10s cooldown). Modelled on `moonraker.sh`'s `start_moonraker_with_restart`.
* `app.sh`: `start()` invokes the supervisor instead of the python directly. `stop()` kills both so the supervisor doesn't immediately respawn.
* `cloud2lan-bridge.py`:
  - `wait_for_file()` guards the boot-time reads of `/userdata/app/gk/config/{device.ini,api.cfg,device_account.json}` and `/useremain/dev/{version,device_id}`.
  - `wait_for_tcp()` gates `connect_lan_mqtt()` on gklib's broker (`127.0.0.1:9883`) actually being open.
  - Both `connect_*_mqtt()` now retry with exponential backoff and have a bounded 30s CONNACK wait (was unbounded).
  - `on_disconnect` callbacks added so drops are visible in the log.
  - Message callbacks wrapped in `try/except` so a single bad payload doesn't kill the path silently.
  - Main loop logs a heartbeat with connection state every 5 minutes.
  - `__main__` uses `sys.exit(1)` instead of `os.kill(SIGKILL)` so the supervisor sees a clean non-zero exit.

Drive-bys: dropped the unused `base64` import, simplified `not not os.getenv("DEBUG")`.