### PR TITLE
Add application for unbiased bed mesh probing

### DIFF
--- a/apps/unbiased-bed-mesh/README.md
+++ b/apps/unbiased-bed-mesh/README.md
@@ -1,0 +1,53 @@
+# Unbiased Bed Mesh
+
+A Rinkhals app for Anycubic Kobra printers. It probes the bed mesh point by point, spiralling onto each point so the direction the head arrives from stops skewing the reading. That cancels the probe bias baked into Klipper's snake-pattern calibration.
+
+## The problem
+
+`BED_MESH_CALIBRATE` walks the bed in a snake: one row is probed moving in +X, the next moving in -X, and so on. The strain gauge probe on a Kobra reads a slightly different Z depending on which way along X the head was travelling when it touched down. On one K3 that came to roughly ±0.02 to ±0.08 mm, and the error grew about threefold from one part of the bed to another. Since alternate rows are probed in opposite X directions, the error alternates with them, and the saved mesh ends up with a zigzag that prints as an uneven first layer.
+
+## What it does
+
+For every point it spirals in through all four quadrants and touches down only at the end, so both X belt directions are exercised before the reading and no single direction can dominate. Step by step:
+
+1. Reads the current mesh geometry from Moonraker (the `bed_mesh` and `bed_mesh default` objects).
+2. Homes, heats the bed to 60°C and the hotend to 170°C, wipes the nozzle, then cools the hotend to 140°C for probing, mirroring GoKlipper's own `BED_MESH_CALIBRATE` heating sequence. From a cold printer this alone can take several minutes.
+3. Walks the mesh row by row, from low Y to high Y, approaching each row from the same side.
+4. Spirals onto each point (eight segments, four quadrants, about 47 mm of travel at 1500 mm/min) and probes once it arrives.
+5. Probes with `SAMPLE_RETRACT_DIST=5` to work around the strain gauge triggering again on the next sample.
+6. Writes the mesh into `printer_mutable.cfg` using the same JSON layout GoKlipper writes, leaving any other keys (such as `input_shaper`) untouched.
+7. Reminds you to restart Klipper yourself (from the UI, or with `restart_klipper.sh`). It does not restart Klipper for you, because that leaves the printer in an unmanaged state on Kobra firmware.
+
+It runs once and exits. No daemon, nothing watching files, nothing that starts it on its own.
+
+## Before you run it
+
+Run a normal `BED_MESH_CALIBRATE` at least once on the current geometry first. That fills in `printer_mutable.cfg`, and this app reads `mesh_min`, `mesh_max`, `probe_count`, `mesh_x_pps`, `mesh_y_pps`, `algo`, and `tension` from it. If the file is empty, for example after you change the `[bed_mesh]` section, the app stops with a clear message.
+
+## Running it
+
+From the Rinkhals UI, tap Start on the app card. Over SSH:
+
+```sh
+/useremain/home/rinkhals/apps/unbiased-bed-mesh/app.sh start
+```
+
+Either way, `start` returns immediately: it hands the run off to `compensator.py` in the background and gets out of the way. The run itself takes longer: heating first (a few minutes from a cold printer), then probing at roughly 10 s per point (about 17 minutes for a 10x10 mesh). Watch it with:
+
+```sh
+tail -f /tmp/unbiased-bed-mesh.log
+```
+
+or check the app's "Last run" property in the UI once it finishes. To abort a run in progress, use `app.sh stop` (or Stop in the UI); it cools the bed and hotend down and restores the gcode state before exiting.
+
+## The `.disabled` marker
+
+The app ships with a `.disabled` file next to it. In Rinkhals that marks an app as disabled, so the system never starts it on its own at boot. That is deliberate: this app moves the toolhead, and it must never start by itself.
+
+You start it yourself, from the UI or over SSH, and `app.sh` re-creates the marker on every start so the app stays disabled and out of autostart. If the marker is gone, which is what happens once someone enables the app, `app.sh` refuses to run at all, so an accidental autostart can never send the head spiralling across the bed.
+
+If you remove the marker, put it back:
+
+```sh
+touch /useremain/home/rinkhals/apps/unbiased-bed-mesh/.disabled
+```

--- a/apps/unbiased-bed-mesh/app.json
+++ b/apps/unbiased-bed-mesh/app.json
@@ -1,0 +1,20 @@
+{
+    "$version": "1",
+
+    "name": "Unbiased Bed Mesh",
+    "description": "Requires restart after run: the new mesh only applies once you restart Klipper manually. Probes a full bed mesh with a tension-relaxing spiral approach per point, eliminating directional probe bias at the source, then writes the result into printer_mutable.cfg. One-shot: invoke manually from the UI or via SSH when you want a fresh mesh.",
+    "version": "0.1.0",
+    "url": "https://github.com/rinkhals-community/Rinkhals.Apps/tree/master/apps/unbiased-bed-mesh",
+
+    "requirements": {
+        "cpu": 1,
+        "memory": 10
+    },
+
+    "properties": {
+        "last_result": {
+            "display": "Last run",
+            "type": "report"
+        }
+    }
+}

--- a/apps/unbiased-bed-mesh/app.sh
+++ b/apps/unbiased-bed-mesh/app.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# shellcheck disable=SC1091
+. /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname "$(realpath "$0")")
+APP_NAME=unbiased-bed-mesh
+LOG_FILE=/tmp/${APP_NAME}.log
+
+# Single source of truth for "is the app currently running?".
+# report_status / status output do NOT set an exit code, so we can't rely on
+# `status >/dev/null` like a sysvinit script. We check PIDs directly instead.
+running_pids() {
+    get_by_name compensator.py
+}
+
+status() {
+    PIDS=$(running_pids)
+
+    if [ "$PIDS" = "" ]; then
+        report_status $APP_STATUS_STOPPED
+    else
+        report_status $APP_STATUS_STARTED "$PIDS" "$LOG_FILE"
+    fi
+}
+
+start() {
+    # Safety gate: refuse to run unless .disabled marker is present. This
+    # makes the app safe by construction: if some external actor (UI "enable"
+    # button, boot autostart) removes the marker, the app will not probe.
+    # Touch the marker on every start to re-assert the safe state.
+    if [ ! -e "$APP_ROOT/.disabled" ]; then
+        log "${APP_NAME}: refusing to run, .disabled marker missing"
+        return 0
+    fi
+    touch "$APP_ROOT/.disabled"
+
+    PIDS=$(running_pids)
+    if [ "$PIDS" != "" ]; then
+        log "${APP_NAME} already running (pids: $PIDS), nothing to do"
+        return 0
+    fi
+
+    cd $APP_ROOT
+    nohup python ./compensator.py "$APP_ROOT/app.json" >> $LOG_FILE 2>&1 &
+    log "Started ${APP_NAME} from $APP_ROOT (pid: $!)"
+}
+
+stop() {
+    PIDS=$(running_pids)
+    if [ "$PIDS" = "" ]; then
+        log "${APP_NAME} not running, nothing to stop"
+        return 0
+    fi
+
+    kill_by_name compensator.py
+    log "Stopped ${APP_NAME}"
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop}" >&2
+        exit 1
+        ;;
+esac

--- a/apps/unbiased-bed-mesh/compensator.py
+++ b/apps/unbiased-bed-mesh/compensator.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+"""
+unbiased-bed-mesh: one-shot custom bed-mesh probe.
+
+Replaces GoKlipper's bias-prone snake probing with a per-point spiral
+approach that washes out directional bias by traversing the area around
+each probe point from every direction before touching down. The spiral is
+intentionally slow to let belts and cables relax.
+
+On invocation:
+  1. Reads the active mesh geometry from Moonraker
+     (printer.objects.query → bed_mesh / bed_mesh default). If no mesh
+     exists yet, exits with an actionable error.
+  2. Walks the full N x M grid row by row (low Y to high Y), normalising
+     Y approach direction once per row, then spiraling into each point.
+  3. Subtracts probe.z_offset from each trigger Z so the round-trip
+     cancels (GoKlipper applies stored + z_offset during prints).
+  4. Writes the probed values into printer_mutable.cfg in the same
+     schema GoKlipper itself uses, preserving any other top-level keys
+     in the file (e.g. input_shaper).
+  5. Logs a reminder that Klipper must be restarted manually for the
+     new mesh to take effect.
+
+Module layout:
+  log.py       shared timestamped logger
+  ws_client.py JSON-RPC WebSocket transport to Moonraker
+  mesh.py      Point / BedMeshConfig + file I/O (mutable cfg, app.json)
+  printer.py   Klipper protocol calls, motion, heating, spiral probing
+  compensator.py (this file) orchestration only
+"""
+
+import signal
+import sys
+from itertools import groupby
+from typing import Any
+
+from log import log
+from mesh import (
+    LOG_FILE_HINT,
+    MUTABLE_CFG_PATH,
+    BedMeshConfig,
+    Point,
+    build_grid,
+    log_mesh_table,
+    write_mesh_to_mutable,
+    write_status,
+)
+from printer import (
+    GCODE_STATE_NAME,
+    MOVE_TIMEOUT_S,
+    PROBE_MAX_ATTEMPTS,
+    ProbeCollector,
+    cool_down,
+    heat_up,
+    identify,
+    preflight_ok,
+    prepare_row,
+    probe_with_retry,
+    query_bed_mesh,
+    query_probe_z_offset,
+)
+from ws_client import JsonRpcWebSocket, WebSocketError
+
+
+def install_sigterm_handler(ws: JsonRpcWebSocket) -> None:
+    """
+    On SIGTERM (e.g. `app.sh stop`), turn heaters off, best-effort restore
+    the gcode state, and exit non-zero. Cooling comes first: a stop during
+    heating must not leave the bed and hotend energized. Never blocks forever.
+    """
+
+    def handler(signum: int, frame: Any) -> None:
+        log(f"caught signal {signum}, cooling down and restoring state before exit")
+        cool_down(ws)
+        try:
+            ws.call(
+                "printer.gcode.script",
+                params={"script": f"RESTORE_GCODE_STATE NAME={GCODE_STATE_NAME}"},
+                timeout=MOVE_TIMEOUT_S,
+            )
+        except (WebSocketError, TimeoutError, OSError) as e:
+            log(f"RESTORE on signal failed: {type(e).__name__}: {e}")
+        sys.exit(2)
+
+    signal.signal(signal.SIGTERM, handler)
+
+
+def main() -> int:
+    # Optional positional argument: path to this app's app.json, used to
+    # update the UI "Last run" report property. The script intentionally
+    # does not infer its own location, see app.sh.
+    app_json_path: str | None = sys.argv[1] if len(sys.argv) > 1 else None
+    log(f"unbiased-bed-mesh: one-shot start (app.json={app_json_path})")
+
+    step: str = "startup"
+    collector: ProbeCollector = ProbeCollector()
+
+    try:
+        with JsonRpcWebSocket() as ws:
+            identify(ws, app_json_path)
+            ws.subscribe("notify_gcode_response", collector)
+
+            step = "query bed mesh geometry"
+            cfg: BedMeshConfig | None = query_bed_mesh(ws)
+            if cfg is None:
+                msg = (
+                    "no bed mesh found in Moonraker state. "
+                    "Run a standard BED_MESH_CALIBRATE first to establish "
+                    "mesh geometry, then re-run this app."
+                )
+                log(msg)
+                write_status(
+                    app_json_path,
+                    f"FAILED at {step} - no mesh geometry. See {LOG_FILE_HINT}",
+                )
+                return 1
+
+            nx, ny = cfg.probe_count
+            log(
+                f"mesh: {nx}x{ny} points, "
+                f"min=({cfg.mesh_min.x},{cfg.mesh_min.y}), "
+                f"max=({cfg.mesh_max.x},{cfg.mesh_max.y}), "
+                f"algo={cfg.algorithm}"
+            )
+
+            step = "preflight"
+            if not preflight_ok(ws):
+                write_status(
+                    app_json_path,
+                    f"FAILED at {step} - printer busy. See {LOG_FILE_HINT}",
+                )
+                return 1
+
+            step = "query probe.z_offset"
+            z_offset: float = query_probe_z_offset(ws)
+            log(f"probe.z_offset = {z_offset:+.4f}")
+
+            grid: list[Point] = build_grid(cfg)
+            install_sigterm_handler(ws)
+
+            # Everything from here commands heaters and motion. Wrap it all
+            # in one try/finally so any failure (heat timeout, rejected macro,
+            # dropped socket, probe abort) still restores the gcode state and
+            # cools the bed and hotend. M109 / M190 block until temps reach
+            # setpoint, so heating can take several minutes on a cold printer.
+            step = "heating"
+            probe_failed: bool = False
+            zs: list[float] = []
+            try:
+                heat_up(ws)
+
+                ws.call(
+                    "printer.gcode.script",
+                    params={"script": f"SAVE_GCODE_STATE NAME={GCODE_STATE_NAME}"},
+                    timeout=MOVE_TIMEOUT_S,
+                )
+                ws.call(
+                    "printer.gcode.script",
+                    params={"script": "G90"},
+                    timeout=MOVE_TIMEOUT_S,
+                )
+
+                step = "probing"
+                for _, row_iter in groupby(grid, key=lambda p: p.y):
+                    row: list[Point] = list(row_iter)
+                    prepare_row(ws, row[0])
+                    for p in row:
+                        z: float | None = probe_with_retry(ws, collector, p)
+                        if z is None:
+                            log(
+                                f"point {p}: failed after {PROBE_MAX_ATTEMPTS} "
+                                f"attempts, aborting"
+                            )
+                            probe_failed = True
+                            break
+                        zs.append(z)
+                        log(f"point {p}: z={z:+.4f}")
+                    if probe_failed:
+                        break
+            finally:
+                try:
+                    ws.call(
+                        "printer.gcode.script",
+                        params={
+                            "script": f"RESTORE_GCODE_STATE NAME={GCODE_STATE_NAME}"
+                        },
+                        timeout=MOVE_TIMEOUT_S,
+                    )
+                except (WebSocketError, TimeoutError, OSError) as e:
+                    log(f"RESTORE_GCODE_STATE failed: {e}")
+                cool_down(ws)
+
+            if probe_failed:
+                write_status(
+                    app_json_path,
+                    f"FAILED at {step} - probe gave up after "
+                    f"{PROBE_MAX_ATTEMPTS} attempts. See {LOG_FILE_HINT}",
+                )
+                return 1
+
+            step = "writing mesh"
+            # Subtract probe.z_offset from each raw trigger-Z so the round
+            # trip cancels: GoKlipper applies stored + z_offset during print,
+            # so storing (raw - z_offset) yields the raw trigger height as
+            # the effective bed-relative adjustment. Matches native
+            # BED_MESH_CALIBRATE storage semantics.
+            raw_mean: float = sum(zs) / len(zs)
+            zs_corrected: list[float] = [z - z_offset for z in zs]
+            corrected_mean: float = sum(zs_corrected) / len(zs_corrected)
+            log(
+                f"means: raw={raw_mean:+.4f} z_offset={z_offset:+.4f} "
+                f"corrected={corrected_mean:+.4f}"
+            )
+            log_mesh_table(grid, zs_corrected)
+            write_mesh_to_mutable(MUTABLE_CFG_PATH, cfg, zs_corrected)
+            log(f"wrote mesh to {MUTABLE_CFG_PATH}")
+            log(
+                "NOTE: restart Klipper manually (UI or restart_klipper.sh) "
+                "for the new mesh to take effect."
+            )
+
+            write_status(
+                app_json_path,
+                f"ok, {len(zs)} points (mean {corrected_mean:+.4f}, "
+                f"z_offset {z_offset:+.4f}). Restart Klipper to apply.",
+            )
+
+    except (WebSocketError, OSError, TimeoutError, ValueError) as e:
+        msg = f"{type(e).__name__}: {e}"
+        log(f"run failed at {step}: {msg}")
+        write_status(
+            app_json_path,
+            f"FAILED at {step} - {msg}. See {LOG_FILE_HINT}",
+        )
+        return 1
+
+    log("unbiased-bed-mesh: done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/unbiased-bed-mesh/log.py
+++ b/apps/unbiased-bed-mesh/log.py
@@ -1,0 +1,6 @@
+"""Shared timestamped logger. All modules in this app import `log` from here."""
+from datetime import datetime
+
+
+def log(msg: str) -> None:
+    print(f"{datetime.now().isoformat(timespec='seconds')} {msg}", flush=True)

--- a/apps/unbiased-bed-mesh/mesh.py
+++ b/apps/unbiased-bed-mesh/mesh.py
@@ -1,0 +1,207 @@
+"""
+Mesh data types, geometry helpers, and the two files we write:
+printer_mutable.cfg (the mesh itself) and app.json (the UI status line).
+
+This module has no WebSocket / printer awareness: pure data and disk I/O.
+"""
+
+import json
+import os
+import tempfile
+from itertools import groupby
+from typing import Any, NamedTuple
+
+from log import log
+
+MUTABLE_CFG_PATH: str = "/userdata/app/gk/printer_mutable.cfg"
+LOG_FILE_HINT: str = (
+    "/tmp/unbiased-bed-mesh.log"  # informational; shell redirects stdout/stderr here
+)
+
+
+class Point(NamedTuple):
+    """A bed-coordinate measurement point."""
+
+    x: float
+    y: float
+
+    def __str__(self) -> str:
+        return f"({self.x:.2f}, {self.y:.2f})"
+
+
+class BedMeshConfig(NamedTuple):
+    """Mesh geometry as reported by Moonraker."""
+
+    mesh_min: Point
+    mesh_max: Point
+    probe_count: tuple[int, int]  # (x_count, y_count)
+    mesh_pps: tuple[int, int]  # (mesh_x_pps, mesh_y_pps)
+    algorithm: str
+    tension: float
+
+
+# ---------- grid construction ----------
+
+
+def build_grid(cfg: BedMeshConfig) -> list[Point]:
+    """
+    Return a flat list of probe points, ordered low Y to high Y and low X
+    to high X within each Y. Coordinates are linearly spaced from
+    `mesh_min` to `mesh_max`, inclusive, with `probe_count` samples per
+    axis.
+    """
+    nx, ny = cfg.probe_count
+    if nx < 2 or ny < 2:
+        raise ValueError(
+            f"probe_count must be >= 2 on each axis, got {cfg.probe_count}"
+        )
+
+    def axis(lo: float, hi: float, n: int) -> list[float]:
+        step: float = (hi - lo) / (n - 1)
+        return [lo + i * step for i in range(n)]
+
+    xs: list[float] = axis(cfg.mesh_min.x, cfg.mesh_max.x, nx)
+    ys: list[float] = axis(cfg.mesh_min.y, cfg.mesh_max.y, ny)
+    return [Point(x, y) for y in ys for x in xs]
+
+
+def log_mesh_table(grid: list[Point], zs: list[float]) -> None:
+    """Log the probed Z values as a Y-descending grid (top = +Y)."""
+    rows: list[list[tuple[Point, float]]] = [
+        list(r) for _, r in groupby(zip(grid, zs), key=lambda pz: pz[0].y)
+    ]
+    xs: list[float] = [pz[0].x for pz in rows[0]]
+    log("probed mesh (mm):")
+    log("           " + "  ".join(f"x={x:6.1f}" for x in xs))
+    for row in reversed(rows):
+        cells: str = "  ".join(f"{z:+8.4f}" for _, z in row)
+        log(f"  y={row[0][0].y:6.1f}  {cells}")
+
+
+# ---------- printer_mutable.cfg ----------
+
+
+def _fmt_num(v: Any) -> str:
+    """
+    Format a number for printer_mutable.cfg in the same shape GoKlipper
+    uses: whole floats render as ints (e.g. 10.0 -> "10"), the rest as
+    their string representation.
+    """
+    if isinstance(v, float) and v.is_integer():
+        return str(int(v))
+    return str(v)
+
+
+def _format_points(zs: list[float], nx: int, ny: int) -> str:
+    """
+    Render the probed Z values as the on-disk `points` string: rows joined
+    with '\\n', values within a row joined with ', ', each value formatted
+    as %.6f. `zs` is a flat list in row-major order (low Y first).
+    """
+    if len(zs) != nx * ny:
+        raise ValueError(f"expected {nx * ny} z values, got {len(zs)}")
+    rows: list[str] = []
+    for r in range(ny):
+        row_vals: list[float] = zs[r * nx : (r + 1) * nx]
+        rows.append(", ".join(f"{z:.6f}" for z in row_vals))
+    return "\n".join(rows)
+
+
+def write_mesh_to_mutable(
+    path: str,
+    cfg: BedMeshConfig,
+    zs: list[float],
+) -> None:
+    """
+    Read printer_mutable.cfg (if present), replace the `bed_mesh default`
+    block with our values, write back atomically. Other top-level keys
+    (input_shaper, etc.) are preserved.
+    """
+    data: dict[str, Any] = {}
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                log(
+                    f"warning: existing mutable cfg is not valid JSON ({e}), overwriting"
+                )
+                data = {}
+
+    nx, ny = cfg.probe_count
+    data["bed_mesh default"] = {
+        "algo": cfg.algorithm,
+        "max_x": _fmt_num(cfg.mesh_max.x),
+        "max_y": _fmt_num(cfg.mesh_max.y),
+        "mesh_x_pps": _fmt_num(cfg.mesh_pps[0]),
+        "mesh_y_pps": _fmt_num(cfg.mesh_pps[1]),
+        "min_x": _fmt_num(cfg.mesh_min.x),
+        "min_y": _fmt_num(cfg.mesh_min.y),
+        "points": _format_points(zs, nx, ny),
+        "tension": _fmt_num(cfg.tension),
+        "version": "1",
+        "x_count": str(nx),
+        "y_count": str(ny),
+    }
+
+    # Atomic write: tmp file in the same dir, rename over the target.
+    dirname: str = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix=".mutable.", suffix=".tmp", dir=dirname)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, sort_keys=True, indent=4)
+        os.rename(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------- app.json status report ----------
+
+
+def read_app_json(app_json_path: str | None) -> dict[str, Any]:
+    """
+    Load app.json and return its parsed object, or {} when the path is None,
+    missing, or not valid JSON. Never raises: callers use it for best-effort
+    metadata and must tolerate an empty dict.
+    """
+    if not app_json_path or not os.path.isfile(app_json_path):
+        return {}
+    try:
+        with open(app_json_path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log(f"warning: reading {app_json_path} failed: {e}")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def write_status(app_json_path: str | None, text: str) -> None:
+    """
+    Update properties.last_result.default in app.json so the Rinkhals UI shows
+    the last-run status. No-op when app_json_path is None or unreachable; any
+    failure here is logged but never raised (status update must not mask the
+    real run result).
+    """
+    if not app_json_path:
+        return
+    if not os.path.isfile(app_json_path):
+        log(f"warning: cannot update status, {app_json_path} not found")
+        return
+    try:
+        with open(app_json_path) as f:
+            data = json.load(f)
+        props = data.setdefault("properties", {})
+        last = props.setdefault(
+            "last_result", {"display": "Last run", "type": "report"}
+        )
+        last["default"] = text
+        tmp = app_json_path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=4)
+        os.rename(tmp, app_json_path)
+    except (OSError, json.JSONDecodeError) as e:
+        log(f"warning: updating {app_json_path} failed: {e}")

--- a/apps/unbiased-bed-mesh/printer.py
+++ b/apps/unbiased-bed-mesh/printer.py
@@ -1,0 +1,421 @@
+"""
+Klipper/GoKlipper-specific helpers: protocol calls, motion primitives,
+heating, and the spiral probing loop. Everything that issues G-code or
+queries `printer.objects.*` lives here.
+"""
+
+import os
+import re
+from re import Pattern
+from typing import Any
+
+from log import log
+from mesh import BedMeshConfig, Point, read_app_json
+from ws_client import JsonRpcWebSocket, WebSocketError
+
+# ---------- spiral geometry ----------
+
+# Spiral waypoints, expressed as (dx, dy) offsets from the probe point.
+# Klipper draws straight lines between consecutive waypoints, so the path
+# is a polygonal in-spiral that hits four quadrants with decreasing radius
+# and lands exactly on the probe point. The first waypoint is reached from
+# wherever the head currently sits (Y-normalised row start).
+SPIRAL_WAYPOINTS: tuple[tuple[int, int], ...] = (
+    (8, 0),
+    (0, 7),
+    (-6, 0),
+    (0, -5),
+    (4, 0),
+    (0, 3),
+    (-2, 0),
+    (1, 0),
+    (0, 0),
+)
+SPIRAL_FEEDRATE: int = 1500  # mm/min, slow on purpose so belts relax
+
+
+# ---------- probing parameters ----------
+
+# Strain-gauge probes on Kobra stay triggered briefly after touchdown. The
+# default sample_retract_dist of 2 mm puts the second internal sample back
+# into the still-triggered zone and probing aborts on samples_tolerance.
+# 5 mm gives the gauge time to relax between samples.
+#
+# Confirmed by disassembling gklib 2.4.6.7 (Cmd_PROBE calls Probe, which
+# calls Run_probe). PROBE accepts these overrides:
+#   LIFT_SPEED                    mm/s, retract/lift speed
+#   PROBE_SPEED                   mm/s, descent speed
+#   SAMPLES                       touchdowns per point
+#   SAMPLES_RESULT                average or median
+#   SAMPLES_TOLERANCE             mm, max spread across samples
+#   SAMPLES_TOLERANCE_RETRIES     retries before giving up
+#   SAMPLE_RETRACT_DIST           mm, retract before the next sample
+PROBE_GCODE: str = "PROBE SAMPLE_RETRACT_DIST=5.0"
+PROBE_MAX_ATTEMPTS: int = 2
+
+
+# ---------- heating profile ----------
+
+# Mirrors the wrapped BED_MESH_CALIBRATE in kobra.py. Bed and hotend are
+# brought to printing conditions, then the hotend is cooled to a lower
+# temperature for the actual probing so that nozzle thermal expansion
+# doesn't drift the trigger height between touchdowns.
+BED_TEMP_C: int = 60
+HOTEND_PREHEAT_C: int = 170
+HOTEND_PROBE_C: int = 140
+HEAT_TIMEOUT_S: float = 600.0  # bed warm-up from cold can take ~5 minutes
+
+# WIPE_ENTER / WIPE_EXIT exist only on KS1 / KS1M; other models ship the
+# bare WIPE_NOZZLE and would error on enter/exit. Model code is exported by
+# tools.sh and inherited through app.sh.
+KOBRA_MODEL_CODE: str = os.environ.get("KOBRA_MODEL_CODE", "")
+WIPE_POSITIONING_MODELS: tuple[str, ...] = ("KS1", "KS1M")
+
+
+# ---------- motion parameters ----------
+
+SAFE_Z_MM: float = 5.0  # height to lift to before any horizontal move
+Y_NORMALIZE_OFFSET_MM: float = 5.0  # distance below a row used to seed +Y
+Z_HOP_FEEDRATE: int = 3000  # mm/min for Z moves
+XY_FEEDRATE: int = 6000  # mm/min for general X/Y travel (non-spiral)
+PROBE_TIMEOUT_S: float = 60.0
+MOVE_TIMEOUT_S: float = 30.0
+
+
+# ---------- gcode state name (shared with main + signal handler) ----------
+
+GCODE_STATE_NAME: str = "unbiased_mesh"
+
+
+# ---------- probe result parsing ----------
+
+# Parses GoKlipper's averaged probe result, e.g. "Result is z=-0.186400".
+RESULT_RE: Pattern[str] = re.compile(r"Result is z=(-?\d+(?:\.\d+)?)")
+
+
+class ProbeCollector:
+    """
+    Subscribed handler for `notify_gcode_response`. Accumulates incoming
+    response lines into a list that the probing loop drains around each
+    PROBE call.
+    """
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def __call__(self, params: Any) -> None:
+        if isinstance(params, list):
+            for item in params:
+                self.lines.append(str(item))
+
+    def clear(self) -> None:
+        self.lines.clear()
+
+    def find_result(self) -> float | None:
+        """Return the parsed Z from the latest `Result is z=...` line, or None."""
+        for line in reversed(self.lines):
+            m = RESULT_RE.search(line)
+            if m:
+                return float(m.group(1))
+        return None
+
+
+# ---------- moonraker queries ----------
+
+
+# Moonraker client_name is an identifier, so keep the app slug (matches the
+# app directory and app.sh); version / url are read from app.json at runtime.
+CLIENT_NAME: str = "unbiased-bed-mesh"
+IDENTIFY_URL_FALLBACK: str = "https://github.com/rinkhals-community/Rinkhals.Apps"
+IDENTIFY_VERSION_FALLBACK: str = "unknown"
+
+
+def identify(ws: JsonRpcWebSocket, app_json_path: str | None = None) -> None:
+    """
+    Identify to Moonraker. Best-effort; a failure never aborts the run.
+    version and url come from app.json so they cannot drift from the
+    canonical values; a missing / unreadable app.json falls back to defaults.
+    """
+    meta = read_app_json(app_json_path)
+    try:
+        ws.call(
+            "server.connection.identify",
+            params={
+                "client_name": CLIENT_NAME,
+                "version": str(meta.get("version", IDENTIFY_VERSION_FALLBACK)),
+                "type": "agent",
+                "url": str(meta.get("url", IDENTIFY_URL_FALLBACK)),
+            },
+        )
+    except (WebSocketError, TimeoutError, OSError) as e:
+        log(f"identify failed (continuing anyway): {e}")
+
+
+def query_probe_z_offset(ws: JsonRpcWebSocket) -> float:
+    """
+    Read the live probe.z_offset from Moonraker's parsed config tree.
+
+    GoKlipper applies `[probe] z_offset` to the mesh value during printing:
+    final_z_adjust = stored_mesh_z + probe_z_offset. To make our raw PROBE
+    results (which are trigger-Z in toolhead coords) round-trip correctly,
+    we must pre-subtract z_offset before writing the mesh.
+
+    Source: `configfile.settings.probe.z_offset`. Note this tree is populated
+    from printer_mutable.cfg at Klipper startup; if z_offset was changed via
+    Z_OFFSET_APPLY_PROBE in the same session and no restart has happened
+    since, the live value may differ. Document, do not work around.
+
+    Raises ValueError if the value is missing or non-numeric.
+    """
+    q = ws.call(
+        "printer.objects.query",
+        params={"objects": {"configfile": ["settings"]}},
+    )
+    settings: dict[str, Any] = (
+        (q or {}).get("status", {}).get("configfile", {}).get("settings", {})
+    )
+    probe = settings.get("probe")
+    if not isinstance(probe, dict):
+        raise ValueError("configfile.settings.probe is missing or not a dict")
+    if "z_offset" not in probe:
+        raise ValueError("configfile.settings.probe.z_offset is missing")
+    try:
+        return float(probe["z_offset"])
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"probe.z_offset is not numeric: {probe['z_offset']!r}") from e
+
+
+def preflight_ok(ws: JsonRpcWebSocket) -> bool:
+    """
+    Returns True if it is safe to drive the head: printer is not printing
+    or paused. We do NOT check homed_axes here. heat_up runs G28 first, and
+    an unhomed printer at start is the normal case for a fresh boot or after
+    sitting idle.
+    """
+    try:
+        q = ws.call(
+            "printer.objects.query",
+            params={
+                "objects": {
+                    "print_stats": ["state"],
+                }
+            },
+        )
+    except WebSocketError as e:
+        log(f"preflight query failed: {e}")
+        return False
+
+    status: dict[str, Any] = (q or {}).get("status", {})
+    state: str = str(status.get("print_stats", {}).get("state", ""))
+
+    if state in ("printing", "paused"):
+        log(f"refusing: printer state is {state!r}")
+        return False
+    log(f"preflight ok: state={state!r}")
+    return True
+
+
+def query_bed_mesh(ws: JsonRpcWebSocket) -> BedMeshConfig | None:
+    """
+    Read the current mesh geometry from Moonraker. Returns None if no
+    mesh has ever been calibrated (caller should bail with a clear error).
+
+    Note: on GoKlipper, the `bed_mesh` and `bed_mesh default` objects are
+    synthesized from printer_mutable.cfg by the Rinkhals Moonraker patch.
+    They are populated iff a previous BED_MESH_CALIBRATE wrote the file.
+    """
+    try:
+        q = ws.call(
+            "printer.objects.query",
+            params={"objects": {"bed_mesh": None, "bed_mesh default": None}},
+        )
+    except WebSocketError as e:
+        log(f"bed_mesh query failed: {e}")
+        return None
+
+    status: dict[str, Any] = (q or {}).get("status", {})
+    bm: dict[str, Any] = status.get("bed_mesh", {})
+    bmd: dict[str, Any] = status.get("bed_mesh default", {})
+    params: dict[str, Any] = bmd.get("mesh_params", {}) if isinstance(bmd, dict) else {}
+
+    if not bm or not params:
+        return None
+
+    return BedMeshConfig(
+        mesh_min=Point(float(params["min_x"]), float(params["min_y"])),
+        mesh_max=Point(float(params["max_x"]), float(params["max_y"])),
+        probe_count=(int(params["x_count"]), int(params["y_count"])),
+        mesh_pps=(int(params["mesh_x_pps"]), int(params["mesh_y_pps"])),
+        algorithm=str(params["algo"]),
+        tension=float(params["tension"]),
+    )
+
+
+# ---------- probing motion ----------
+
+
+def prepare_row(ws: JsonRpcWebSocket, first: Point) -> None:
+    """
+    Normalise the Y approach for a row of probes: lift Z, jump below the
+    row's first point, then move +Y onto the row. After this every probe
+    in the row shares the same Y history; inter-point spiraling is X/Y
+    around each probe point without large Y direction changes.
+    """
+    moves: list[str] = [
+        f"G0 Z{SAFE_Z_MM:.2f} F{Z_HOP_FEEDRATE}",
+        f"G1 X{first.x:.3f} Y{first.y - Y_NORMALIZE_OFFSET_MM:.3f} F{XY_FEEDRATE}",
+        f"G1 X{first.x:.3f} Y{first.y:.3f} F{XY_FEEDRATE}",
+    ]
+    for gcode in moves:
+        ws.call(
+            "printer.gcode.script",
+            params={"script": gcode},
+            timeout=MOVE_TIMEOUT_S,
+        )
+
+
+def spiral_then_probe(
+    ws: JsonRpcWebSocket,
+    collector: ProbeCollector,
+    p: Point,
+) -> float | None:
+    """
+    Run the in-spiral around `p` at SPIRAL_FEEDRATE, ending exactly on `p`,
+    then PROBE. Returns the parsed Z, or None if no Result line was seen.
+    A failed PROBE (e.g. samples_tolerance) raises WebSocketError; the
+    caller handles retries via probe_with_retry.
+    """
+    for dx, dy in SPIRAL_WAYPOINTS:
+        gcode: str = f"G1 X{p.x + dx:.3f} Y{p.y + dy:.3f} F{SPIRAL_FEEDRATE}"
+        ws.call(
+            "printer.gcode.script",
+            params={"script": gcode},
+            timeout=MOVE_TIMEOUT_S,
+        )
+
+    collector.clear()
+    ws.call(
+        "printer.gcode.script",
+        params={"script": PROBE_GCODE},
+        timeout=PROBE_TIMEOUT_S,
+    )
+    z: float | None = collector.find_result()
+
+    ws.call(
+        "printer.gcode.script",
+        params={"script": f"G0 Z{SAFE_Z_MM:.2f} F{Z_HOP_FEEDRATE}"},
+        timeout=MOVE_TIMEOUT_S,
+    )
+    return z
+
+
+def probe_with_retry(
+    ws: JsonRpcWebSocket,
+    collector: ProbeCollector,
+    p: Point,
+) -> float | None:
+    """
+    Try spiral_then_probe up to PROBE_MAX_ATTEMPTS times. Returns the Z
+    on the first attempt that yields a Result line, or None if every
+    attempt failed. Between attempts we lift Z to SAFE_Z so the next
+    spiral starts from a known height (a probe aborted mid-touchdown can
+    leave Z in an unpredictable state).
+    """
+    for attempt in range(1, PROBE_MAX_ATTEMPTS + 1):
+        last_err: WebSocketError | None = None
+        try:
+            z: float | None = spiral_then_probe(ws, collector, p)
+            if z is not None:
+                if attempt > 1:
+                    log(f"point {p}: succeeded on attempt {attempt}")
+                return z
+            log(f"point {p}: attempt {attempt}: no Result line")
+        except WebSocketError as e:
+            log(f"point {p}: attempt {attempt}: {e}")
+            last_err = e
+
+        # Recovery before the next attempt. What we need depends on what
+        # actually went wrong, so inspect the error message:
+        #   - "Must home axis first": kinematic state was lost mid-run
+        #     (cause unknown; happens occasionally). The only way out is
+        #     a full G28.
+        #   - "samples_tolerance" / other probe failures: head is still
+        #     where it was, axes are still homed. A Z-lift is enough so
+        #     the next spiral starts from a known height.
+        err_msg: str = str(last_err or "")
+        if "home axis" in err_msg.lower():
+            log(f"point {p}: homing lost, running G28 before retry")
+            try:
+                ws.call(
+                    "printer.gcode.script",
+                    params={"script": "G28"},
+                    timeout=PROBE_TIMEOUT_S,
+                )
+                ws.call(
+                    "printer.gcode.script",
+                    params={"script": "G90"},
+                    timeout=MOVE_TIMEOUT_S,
+                )
+            except (WebSocketError, TimeoutError) as e:
+                log(f"point {p}: G28 recovery failed (continuing): {e}")
+        else:
+            try:
+                ws.call(
+                    "printer.gcode.script",
+                    params={"script": f"G0 Z{SAFE_Z_MM:.2f} F{Z_HOP_FEEDRATE}"},
+                    timeout=MOVE_TIMEOUT_S,
+                )
+            except (WebSocketError, TimeoutError) as e:
+                log(f"point {p}: Z-lift recovery failed (continuing): {e}")
+
+    return None
+
+
+# ---------- heating and wiping ----------
+
+
+def heat_up(ws: JsonRpcWebSocket) -> None:
+    """
+    Mirror the heating / wiping sequence from the wrapped BED_MESH_CALIBRATE
+    in kobra.py: home, heat bed and hotend, wipe, cool the hotend to probing
+    temp. Re-home Z last, on the settled hot bed: the bed warps while heating
+    and the wipe nudges the head, so an earlier Z zero would drift.
+
+    WIPE_ENTER / WIPE_EXIT exist only on KS1 / KS1M; other models have the
+    bare WIPE_NOZZLE.
+    """
+    wipe: list[str] = ["WIPE_NOZZLE"]
+    if KOBRA_MODEL_CODE in WIPE_POSITIONING_MODELS:
+        wipe = ["WIPE_ENTER", "WIPE_NOZZLE", "WIPE_EXIT"]
+
+    sequence: list[str] = [
+        f"M140 S{BED_TEMP_C}",  # set bed temperature, non-blocking
+        f"M104 S{HOTEND_PREHEAT_C}",  # set hotend temperature, non-blocking
+        "G28",
+        "MOVE_HEAT_POS",
+        f"M109 S{HOTEND_PREHEAT_C}",  # set hotend and wait
+        *wipe,
+        f"M109 S{HOTEND_PROBE_C}",  # cool hotend to probing temp, wait
+        f"M190 S{BED_TEMP_C}",  # wait for bed
+        "G28 Z",
+    ]
+    for gcode in sequence:
+        log(f"heat: {gcode}")
+        ws.call(
+            "printer.gcode.script",
+            params={"script": gcode},
+            timeout=HEAT_TIMEOUT_S,
+        )
+
+
+def cool_down(ws: JsonRpcWebSocket) -> None:
+    """Turn off heaters and the part fan. Best-effort, never raises."""
+    for gcode in ("TURN_OFF_HEATERS", "M106 S0"):
+        try:
+            ws.call(
+                "printer.gcode.script",
+                params={"script": gcode},
+                timeout=MOVE_TIMEOUT_S,
+            )
+        except (WebSocketError, TimeoutError, OSError) as e:
+            log(f"cool: {gcode} failed (continuing): {e}")

--- a/apps/unbiased-bed-mesh/ws_client.py
+++ b/apps/unbiased-bed-mesh/ws_client.py
@@ -1,0 +1,291 @@
+"""
+Minimal synchronous WebSocket JSON-RPC client for Moonraker.
+
+Why hand-rolled: the printer Python has no `websocket` / `websockets` module,
+the apps repo's Python-dep bundling pipeline (Docker + venv + lib/) is heavy
+overkill for one localhost connection, and our use case is narrow enough to
+fit in one small stdlib-only module:
+  - localhost only, no TLS, no proxy
+  - small text frames only (JSON-RPC messages)
+  - synchronous: send request, wait for matching response, repeat
+  - lifetime: opened for one bias measurement, closed after
+
+Anything beyond that (TLS, fragmentation, large binary frames, reconnect) is
+intentionally out of scope.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import select
+import socket
+import struct
+from collections.abc import Callable
+from typing import Any
+
+WS_GUID: str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+# Frame opcodes (RFC 6455 section 5.2)
+OP_CONT: int = 0x0
+OP_TEXT: int = 0x1
+OP_BINARY: int = 0x2
+OP_CLOSE: int = 0x8
+OP_PING: int = 0x9
+OP_PONG: int = 0xA
+
+
+class WebSocketError(Exception):
+    pass
+
+
+class JsonRpcWebSocket:
+    """
+    A minimal JSON-RPC-over-WebSocket client.
+
+    Usage (context manager, recommended):
+        with JsonRpcWebSocket() as ws:
+            info = ws.call("printer.info")
+            ws.subscribe("notify_gcode_response", lambda params: print(params))
+            ws.pump(timeout=5.0)
+
+    Or manual lifecycle:
+        ws = JsonRpcWebSocket()
+        ws.connect()
+        ws.call("printer.info")
+        ws.close()
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 7125,
+        path: str = "/websocket",
+    ) -> None:
+        self.host: str = host
+        self.port: int = port
+        self.path: str = path
+        self._sock: socket.socket | None = None
+        self._next_id: int = 1
+        self._handlers: dict[str, Callable[[Any], None]] = {}
+        # Buffer for partial recvs across calls
+        self._recv_buf: bytes = b""
+
+    # ----- connection lifecycle -----
+
+    def connect(self, timeout: float = 5.0) -> None:
+        sock = socket.create_connection((self.host, self.port), timeout=timeout)
+        # Switch back to blocking mode; we manage timeouts with select()
+        sock.settimeout(None)
+        self._sock = sock
+        self._handshake()
+
+    def close(self) -> None:
+        if self._sock is None:
+            return
+        try:
+            self._send_frame(OP_CLOSE, b"")
+        except Exception:
+            pass
+        try:
+            self._sock.close()
+        finally:
+            self._sock = None
+
+    def __enter__(self) -> "JsonRpcWebSocket":
+        """Connect on entry so `with JsonRpcWebSocket() as ws:` just works."""
+        if self._sock is None:
+            self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # ----- JSON-RPC API -----
+
+    def call(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        timeout: float = 30.0,
+    ) -> Any:
+        """Send a JSON-RPC request and block until its response arrives."""
+        req_id: int = self._next_id
+        self._next_id += 1
+        msg: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": req_id,
+        }
+        if params is not None:
+            msg["params"] = params
+        self._send_text(json.dumps(msg))
+
+        # Dispatch incoming frames until we get our response. Notifications
+        # received in the meantime are routed to subscribed handlers.
+        while True:
+            payload: Any = self._recv_json(timeout=timeout)
+            if isinstance(payload, dict) and payload.get("id") == req_id:
+                if "error" in payload:
+                    raise WebSocketError(f"RPC error: {payload['error']}")
+                return payload.get("result")
+            self._dispatch(payload)
+
+    def subscribe(self, notification: str, handler: Callable[[Any], None]) -> None:
+        """Register a handler for Moonraker `notify_*` messages."""
+        self._handlers[notification] = handler
+
+    def pump(self, timeout: float = 1.0) -> bool:
+        """
+        Read at most one incoming frame within `timeout` seconds and dispatch
+        it to handlers. Returns True if a frame was processed, False on
+        timeout. Useful when you want to wait for notifications without
+        making an RPC call.
+        """
+        try:
+            payload: Any = self._recv_json(timeout=timeout)
+        except TimeoutError:
+            return False
+        self._dispatch(payload)
+        return True
+
+    # ----- internals: handshake -----
+
+    def _handshake(self) -> None:
+        key_bytes: bytes = os.urandom(16)
+        key_b64: str = base64.b64encode(key_bytes).decode("ascii")
+        request: str = (
+            f"GET {self.path} HTTP/1.1\r\n"
+            f"Host: {self.host}:{self.port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key_b64}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"
+        )
+        assert self._sock is not None
+        self._sock.sendall(request.encode("ascii"))
+
+        header_buf: bytes = b""
+        while b"\r\n\r\n" not in header_buf:
+            chunk: bytes = self._sock.recv(4096)
+            if not chunk:
+                raise WebSocketError("connection closed during handshake")
+            header_buf += chunk
+            if len(header_buf) > 65536:
+                raise WebSocketError("handshake response too large")
+
+        header_end: int = header_buf.index(b"\r\n\r\n") + 4
+        # Any bytes past the header are the first frame data; save them.
+        self._recv_buf = header_buf[header_end:]
+        header_text: str = header_buf[:header_end].decode("iso-8859-1")
+
+        status_line: str = header_text.split("\r\n", 1)[0]
+        if "101" not in status_line:
+            raise WebSocketError(f"unexpected handshake status: {status_line!r}")
+
+        expected: str = base64.b64encode(
+            hashlib.sha1((key_b64 + WS_GUID).encode("ascii")).digest()
+        ).decode("ascii")
+        accept: str | None = None
+        for line in header_text.split("\r\n")[1:]:
+            if ":" in line:
+                name, _, value = line.partition(":")
+                if name.strip().lower() == "sec-websocket-accept":
+                    accept = value.strip()
+                    break
+        if accept != expected:
+            raise WebSocketError(
+                f"bad Sec-WebSocket-Accept: got {accept!r}, expected {expected!r}"
+            )
+
+    # ----- internals: framing -----
+
+    def _send_text(self, text: str) -> None:
+        self._send_frame(OP_TEXT, text.encode("utf-8"))
+
+    def _send_frame(self, opcode: int, payload: bytes) -> None:
+        assert self._sock is not None
+        header: bytes = struct.pack("!B", 0x80 | opcode)  # FIN + opcode
+        length: int = len(payload)
+        # Client frames MUST be masked (RFC 6455 5.3)
+        mask_bit: int = 0x80
+        if length < 126:
+            header += struct.pack("!B", mask_bit | length)
+        elif length < (1 << 16):
+            header += struct.pack("!BH", mask_bit | 126, length)
+        else:
+            header += struct.pack("!BQ", mask_bit | 127, length)
+        mask_key: bytes = os.urandom(4)
+        header += mask_key
+        masked: bytes = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+        self._sock.sendall(header + masked)
+
+    def _recv_exact(self, n: int, timeout: float | None) -> bytes:
+        assert self._sock is not None
+        while len(self._recv_buf) < n:
+            if timeout is not None:
+                ready, _, _ = select.select([self._sock], [], [], timeout)
+                if not ready:
+                    raise TimeoutError(f"timed out waiting for {n} bytes")
+            chunk: bytes = self._sock.recv(max(4096, n - len(self._recv_buf)))
+            if not chunk:
+                raise WebSocketError("connection closed")
+            self._recv_buf += chunk
+        out: bytes = self._recv_buf[:n]
+        self._recv_buf = self._recv_buf[n:]
+        return out
+
+    def _recv_frame(self, timeout: float | None) -> tuple[int, bytes]:
+        """Return (opcode, payload). Reassembles continuation fragments."""
+        opcode_out: int | None = None
+        chunks: list[bytes] = []
+        while True:
+            hdr: bytes = self._recv_exact(2, timeout)
+            b0, b1 = hdr[0], hdr[1]
+            fin: bool = bool(b0 & 0x80)
+            opcode: int = b0 & 0x0F
+            masked: bool = bool(b1 & 0x80)
+            length: int = b1 & 0x7F
+            if length == 126:
+                length = struct.unpack("!H", self._recv_exact(2, timeout))[0]
+            elif length == 127:
+                length = struct.unpack("!Q", self._recv_exact(8, timeout))[0]
+            mask_key: bytes = self._recv_exact(4, timeout) if masked else b""
+            payload: bytes = self._recv_exact(length, timeout) if length else b""
+            if masked:
+                payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+
+            # Control frames: handle inline, never fragment
+            if opcode == OP_PING:
+                self._send_frame(OP_PONG, payload)
+                continue
+            if opcode == OP_PONG:
+                continue
+            if opcode == OP_CLOSE:
+                return (OP_CLOSE, payload)
+
+            if opcode_out is None:
+                opcode_out = opcode
+            chunks.append(payload)
+            if fin:
+                return (opcode_out, b"".join(chunks))
+
+    def _recv_json(self, timeout: float | None) -> Any:
+        opcode, payload = self._recv_frame(timeout)
+        if opcode == OP_CLOSE:
+            raise WebSocketError("server closed connection")
+        if opcode != OP_TEXT:
+            raise WebSocketError(f"unexpected opcode: {opcode}")
+        return json.loads(payload.decode("utf-8"))
+
+    # ----- internals: dispatch -----
+
+    def _dispatch(self, payload: Any) -> None:
+        if not isinstance(payload, dict):
+            return
+        method: str | None = payload.get("method")
+        if method and "id" not in payload:
+            handler = self._handlers.get(method)
+            if handler is not None:
+                handler(payload.get("params"))


### PR DESCRIPTION
## Summary

The vanilla bed mesh probe works very poorly for me. It adds deviation between X+ and X- meshing directions, and the final mesh looks like a zigzag. This app removes the directional effect by slowly spiraling around the probing point.

## Why

Vanilla probing result:

<img width="1776" height="1192" alt="Screenshot 2026-09-03 at 16-12-42 Kobra3" src="https://github.com/user-attachments/assets/32d064ff-75a8-4637-bb5f-746ff1222b1a" />

This app probing result:

<img width="1776" height="1192" alt="Screenshot 2026-09-03 at 16-15-31 Kobra3" src="https://github.com/user-attachments/assets/d4cf2c08-0300-4c34-963d-6477d538f7e9" />

The table dispersion drops from 0.7 to 0.4. Very solid win.

## Changes

Add the app and documentation

## Testing

How did you test this? Include printer model and firmware version if relevant.
For changes that affect hardware behaviour, manual verification on the target printer is strongly preferred.

- [ ] Existing tests in `tests/` still pass (if applicable)
- [X] Manually tested on a real printer (model and firmware) - this is third or fourth version of the app. I live with it around a few months, and it shows very good result.
- [ ] Documentation updated if user-visible behaviour changed

## Related issues

Fixes #
Related to #

## Notes for reviewers

Anything reviewers should pay particular attention to. Risky areas, decisions you went back and forth on, open questions.
